### PR TITLE
feat(skills): improve 5 lowest-scoring skills + add review workflows

### DIFF
--- a/.github/workflows/skill-review-and-optimize.yml
+++ b/.github/workflows/skill-review-and-optimize.yml
@@ -1,0 +1,26 @@
+# Tessl Skill Review & Optimize — review on PRs that touch SKILL.md (no secrets required).
+# Docs: https://github.com/tesslio/skill-review-and-optimize
+name: Skill review and optimize
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review-and-optimize@main
+        # Review-only by default — works without TESSL_API_TOKEN.
+        # Optional: enable optimize after adding repo secret TESSL_API_TOKEN:
+        # with:
+        #   optimize: true
+        #   tessl-token: ${{ secrets.TESSL_API_TOKEN }}
+        # Optional quality gate:
+        #   fail-threshold: 70

--- a/.github/workflows/skill-review-apply-optimize.yml
+++ b/.github/workflows/skill-review-apply-optimize.yml
@@ -1,0 +1,24 @@
+# Apply optimized SKILL.md content from review comment when someone comments /apply-optimize.
+# Docs: https://github.com/tesslio/skill-review-and-optimize
+name: Apply skill optimization
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  apply:
+    if: >
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/apply-optimize')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: tesslio/skill-review-and-optimize@main
+        with:
+          mode: apply

--- a/skills/ai-integration/anthropic-python/SKILL.md
+++ b/skills/ai-integration/anthropic-python/SKILL.md
@@ -1,18 +1,23 @@
 ---
-name: anthropic-python
+name: ai-python-sdk
 description: |
-  Anthropic Python SDK for Claude API integration. Covers messages API,
-  streaming, tool use, vision, error handling, and best practices.
-  Use when building Python applications that call the Claude API.
+  Integrates Python applications with the Claude Messages API via the official SDK —
+  synchronous and async client setup, model selection (Opus/Sonnet/Haiku), system
+  prompts, multi-turn conversations, streaming with text_stream, tool use (function
+  calling) with input_schema, vision with base64 image input, structured error
+  handling (RateLimitError, APIConnectionError, APIStatusError), async batch
+  processing with AsyncAnthropic, usage/token tracking, and Streamlit integration.
 
-  USE WHEN: user mentions "anthropic", "claude api", "anthropic sdk",
-  "anthropic.Anthropic()", "client.messages.create", "claude-opus",
-  "claude-sonnet", "tool_use", "streaming claude", "claude python"
+  USE WHEN: user mentions "claude api python", "messages.create", "claude sdk",
+  "anthropic.Anthropic()", "client.messages.create", "claude-opus", "claude-sonnet",
+  "tool_use python", "streaming claude python", "AsyncAnthropic", "claude vision python",
+  "ANTHROPIC_API_KEY", "claude haiku python"
 
-  DO NOT USE FOR: OpenAI API, other LLM providers, JavaScript/TypeScript Anthropic SDK
+  DO NOT USE FOR: OpenAI API, other LLM providers, JavaScript/TypeScript SDK (use
+  separate skill), LangChain integration (use langchain skill)
 allowed-tools: Read, Grep, Glob, Write, Edit
 ---
-# Anthropic Python SDK
+# Claude Python SDK (Anthropic)
 
 ## Installation
 

--- a/skills/animation/framer-motion/SKILL.md
+++ b/skills/animation/framer-motion/SKILL.md
@@ -1,6 +1,24 @@
-# Framer Motion Skill
+---
+name: framer-motion
+description: |
+  Implements declarative React animations with Framer Motion — mount/unmount
+  transitions via AnimatePresence, spring physics, gesture handlers (hover, tap,
+  drag), scroll-linked motion values, shared layout animations (FLIP), variant
+  orchestration with stagger, and reduced-motion accessibility.
 
-Animation library for React. Declarative, physics-based, gesture-aware.
+  USE WHEN: user mentions "framer-motion", "motion.div", "AnimatePresence",
+  "layout animation", "React animation", "exit animation", "useScroll",
+  "whileHover", "whileTap", "drag gesture", "spring animation", "variants",
+  "staggerChildren", "layoutId", "shared element transition"
+
+  DO NOT USE FOR: GSAP animations, CSS-only animations, Lottie/Rive, React Native
+  animations (use react-native-reanimated), non-React projects
+allowed-tools: Read, Grep, Glob, Write, Edit
+---
+
+# Framer Motion
+
+Declarative React animation library with spring physics, gesture support, layout animations, and scroll-linked motion values.
 
 ## Install
 

--- a/skills/animation/gsap/SKILL.md
+++ b/skills/animation/gsap/SKILL.md
@@ -1,6 +1,24 @@
-# GSAP Skill
+---
+name: gsap
+description: |
+  Builds high-performance JavaScript animations with GSAP — tweens (to/from/fromTo),
+  timeline sequencing with position parameters, ScrollTrigger (pin, scrub, snap),
+  Flip plugin for layout transitions, stagger grids, matchMedia responsive animations,
+  React integration via useGSAP hook with automatic cleanup, and SVG path drawing.
 
-GreenSock Animation Platform — high-performance JS animation engine with plugin ecosystem.
+  USE WHEN: user mentions "gsap", "GreenSock", "ScrollTrigger", "gsap.to",
+  "gsap.timeline", "gsap.from", "useGSAP", "scrub animation", "pin scroll",
+  "GSAP context", "gsap.matchMedia", "Flip plugin", "GSAP stagger",
+  "tween animation", "gsap.registerPlugin"
+
+  DO NOT USE FOR: Framer Motion (React-specific declarative), CSS-only animations,
+  Lottie/Rive, Web Animations API without GSAP
+allowed-tools: Read, Grep, Glob, Write, Edit
+---
+
+# GSAP (GreenSock Animation Platform)
+
+High-performance JavaScript animation engine with timeline sequencing, ScrollTrigger, Flip plugin, and React integration.
 
 ## Install
 

--- a/skills/codegen/codegen-refinement/SKILL.md
+++ b/skills/codegen/codegen-refinement/SKILL.md
@@ -1,6 +1,25 @@
-# Code Generation Refinement Skill
+---
+name: codegen-refinement
+description: |
+  Refines auto-generated code from deterministic generators (openapi-generator,
+  asyncapi-generator, protoc, tsp compile, bpmn-engine) to match project conventions
+  — renames to project naming style, adjusts import paths to aliases, applies project
+  error-handling patterns, improves type safety by removing 'any', and fixes linting
+  issues while preserving the original API contract unchanged.
 
-You are refining AUTO-GENERATED code produced by deterministic code generators (openapi-generator, asyncapi-generator, tsp compile, protoc, bpmn-engine). Your role is to adapt the generated output to match the target project's coding conventions WITHOUT changing the API contract or structural design.
+  USE WHEN: user mentions "refine generated code", "openapi-generator output",
+  "protobuf generated", "adapt codegen", "fix generated types", "match project style",
+  "codegen conventions", "generated code cleanup", "post-generation refinement",
+  "asyncapi generated", "tsp compile output"
+
+  DO NOT USE FOR: writing code from scratch, modifying API contracts/endpoints,
+  restructuring file organization, adding new features beyond the spec
+allowed-tools: Read, Grep, Glob, Write, Edit
+---
+
+# Code Generation Refinement
+
+Adapts auto-generated code from deterministic generators to match project coding conventions without changing the API contract or structural design.
 
 ## Scope
 

--- a/skills/graphics/canvas-webgl/SKILL.md
+++ b/skills/graphics/canvas-webgl/SKILL.md
@@ -1,6 +1,26 @@
-# Canvas / WebGL Skill
+---
+name: canvas-webgl
+description: |
+  Implements browser graphics with Canvas 2D API, WebGL2, and creative coding
+  libraries (p5.js) — React canvas setup with retina scaling, 2D drawing paths and
+  shapes, gradient/pattern fills, transform state management, particle systems,
+  pixel manipulation via ImageData, OffscreenCanvas with Web Workers, WebGL2 shader
+  compilation, p5.js React integration, noise functions, and performance patterns
+  (Path2D caching, object pooling, layer canvases).
 
-Browser graphics via Canvas 2D API, WebGL, and creative coding libraries.
+  USE WHEN: user mentions "canvas 2D", "WebGL", "WebGL2", "canvas animation",
+  "particle system", "pixel manipulation", "getImageData", "OffscreenCanvas",
+  "requestAnimationFrame", "p5.js", "creative coding", "canvas React",
+  "shader", "GLSL", "noise function", "canvas drawing", "ctx.fillRect"
+
+  DO NOT USE FOR: Three.js / React Three Fiber (use three-js skill), SVG animation
+  (use svg-animation skill), CSS animations, server-side rendering
+allowed-tools: Read, Grep, Glob, Write, Edit
+---
+
+# Canvas / WebGL
+
+Browser graphics via Canvas 2D API, WebGL2, and creative coding libraries — with React integration, retina scaling, and performance patterns.
 
 ## Canvas 2D — React Setup
 


### PR DESCRIPTION
Hey @claude-dev-suite 👋

Really impressive project — the breadth of skills covering everything from Spring Boot to creative coding is great, and the architecture with agents + MCP servers + dashboard is well thought out.


<img width="1312" height="910" alt="image" src="https://github.com/user-attachments/assets/57095c26-7243-4a2f-a15c-2d49ff1b8dd2" />


I ran a selection of your skills through **`tessl skill review`** and noticed several that were missing YAML frontmatter entirely (scoring 10%) plus one with a reserved-word naming issue. I've optimized the five lowest-scoring skills with proper frontmatter, trigger terms, and scope boundaries:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| animation/framer-motion | 10% | 96% | +86% |
| animation/gsap | 10% | 91% | +81% |
| codegen/codegen-refinement | 10% | 85% | +75% |
| graphics/canvas-webgl | 10% | 82% | +72% |
| ai-integration/anthropic-python | 17% | 85% | +68% |

With 346 skills in the repo, I intentionally scoped this PR to five to keep it reviewable. The new workflows below will give you ongoing feedback on any future `SKILL.md` changes.

<details>
<summary>Changes summary</summary>

**All five skills received:**
- **YAML frontmatter** with `name`, `description`, and `allowed-tools` fields
- **USE WHEN** trigger terms — specific, natural phrases users would say (e.g. "framer-motion", "gsap.to", "ScrollTrigger", "canvas 2D", etc.)
- **DO NOT USE FOR** boundaries to prevent skill conflicts with similar skills
- **Improved heading** lines with concise one-line descriptions

**Skill-specific fixes:**
- **framer-motion / gsap / canvas-webgl / codegen-refinement**: Added complete frontmatter where none existed — these were failing deterministic validation entirely
- **anthropic-python**: Renamed from `anthropic-python` to `ai-python-sdk` to avoid the reserved-word validation error, expanded description with concrete capabilities (streaming, tool use, vision, async, Streamlit), and improved trigger terms

All changes follow your CONTRIBUTING.md conventions (conventional commits, skill directory structure under `skills/{category}/{technology}/`).

</details>

## GitHub Actions — Tessl skill review + optional optimize

This PR also adds two workflows from [tesslio/skill-review-and-optimize](https://github.com/tesslio/skill-review-and-optimize):

**1. `.github/workflows/skill-review-and-optimize.yml`** — Runs on PRs that change `**/SKILL.md`:
- **No secrets required** for review mode — posts/updates one PR comment with scores and feedback using only `GITHUB_TOKEN`
- **Non-blocking by default** — won't fail CI unless you set `fail-threshold`
- **Optional optimize mode**: Add `TESSL_API_TOKEN` as a repo secret (from [tessl.io](https://tessl.io) account API keys), then set `optimize: true` and `tessl-token: ${{ secrets.TESSL_API_TOKEN }}` on the review step for AI-suggested improvements in the comment

**2. `.github/workflows/skill-review-apply-optimize.yml`** — When optimize mode is on, PR participants can comment **`/apply-optimize`** to have the workflow commit suggested improvements directly to the PR branch.

This is **not a replacement** for any existing skill pipelines — it's review/optimize automation specifically for markdown skills. The five skills in this PR keep the contribution reviewable; the workflows provide ongoing coverage for the rest over time.

Honest disclosure — I work at [tessl.io](https://tessl.io) (@tesslio) where we build tooling around agent skills. Not a pitch, just fixes that were straightforward to make after running evals.

For more on skill optimization: [optimize a skill using best practices](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices). If you hit any snags, feel free to reach out to [@rohan-tessl](https://github.com/rohan-tessl).

Thanks in advance 🙏 — happy to answer any questions or adjust the changes.
