### PR TITLE
Generalize verticals into engine-agnostic architecture skills (P3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`systems/` skill pack** — low-level / systems architecture domains the
   catalog lacked: `os-kernel-architecture`, `embedded-rtos`,
   `systems-networking`, `storage-engines`, `distributed-consensus`,
-  `virtualization`, `hardware-aware-design`.
+  `virtualization`, `hardware-aware-design`, `data-intensive`,
+  `security-architecture`.
 - **`ai-systems/` skill pack** — AI-integrated systems architecture (decision
   layer): `edge-inference`, `inference-serving-topology`, `hybrid-edge-cloud`,
   `ai-hardware-selection`, `model-gateway-routing`, `agentic-architecture`.
+- **Generalized vertical architecture skills** (engine-agnostic counterparts of
+  existing domain-specific packs): `systems/distributed-ledger` (from
+  `bitcoin/*`), `systems/cyber-physical` (from `industrial/*`),
+  `systems/game-engine-architecture` (from `gamedev/unity-*`).
 
 ### Fixed
 

--- a/agents/core/architect.md
+++ b/agents/core/architect.md
@@ -46,6 +46,9 @@ extended_skills:
   - systems/hardware-aware-design
   - systems/data-intensive
   - systems/security-architecture
+  - systems/distributed-ledger
+  - systems/cyber-physical
+  - systems/game-engine-architecture
   # AI-integrated systems architecture
   - ai-systems/edge-inference
   - ai-systems/inference-serving-topology

--- a/docs/AGENT-CAPABILITY-MATRIX.md
+++ b/docs/AGENT-CAPABILITY-MATRIX.md
@@ -8,7 +8,7 @@ This document maps each agent to its required MCP servers and skills.
 
 | Agent | MCP Servers | Skills |
 |-------|-------------|--------|
-| **architect** | documentation, api-explorer, skill-loader | clean-code, solid-principles, token-optimization (core); on demand: web/enterprise (DDD, event-sourcing/CQRS, multitenancy, Spring Cloud, API design), `systems/*` (OS-kernel, embedded-RTOS, systems-networking, storage-engines, distributed-consensus, virtualization, hardware-aware), `ai-systems/*` (edge-inference, inference-serving-topology, hybrid-edge-cloud, ai-hardware-selection, model-gateway-routing, agentic-architecture) |
+| **architect** | documentation, api-explorer, skill-loader | clean-code, solid-principles, token-optimization (core); on demand: web/enterprise (DDD, event-sourcing/CQRS, multitenancy, Spring Cloud, API design), `systems/*` (OS-kernel, embedded-RTOS, systems-networking, storage-engines, distributed-consensus, virtualization, hardware-aware, data-intensive, security-architecture, distributed-ledger, cyber-physical, game-engine), `ai-systems/*` (edge-inference, inference-serving-topology, hybrid-edge-cloud, ai-hardware-selection, model-gateway-routing, agentic-architecture) |
 | **code-reviewer** | documentation, code-quality | clean-code, solid-principles, git-workflow |
 | **typescript-expert** | documentation | typescript, advanced-types |
 | **nodejs-expert** | documentation | nodejs, npm, async-patterns |

--- a/docs/ARCHITECT-MULTI-DOMAIN-PLAN.md
+++ b/docs/ARCHITECT-MULTI-DOMAIN-PLAN.md
@@ -432,8 +432,11 @@ deep-dive narrative. This keeps the loose coupling: agent → skill → KB.
   `knowledge_base` before/with merge, or `fetch_docs` 404s for the new topics.
   Push is outward-facing → awaiting go-ahead. (More topics per technology can be
   added later.)
-- **P3 — Generalize verticals.** PENDING — `bitcoin` → distributed-ledger,
-  `industrial` → cyber-physical, `unity` → game-engine.
+- **P3 — Generalize verticals.** ✅ **DONE 2026-06-01.** Engine-agnostic skills
+  extracted: `systems/distributed-ledger` (from `bitcoin/*`),
+  `systems/cyber-physical` (from `industrial/*`),
+  `systems/game-engine-architecture` (from `gamedev/unity-*`). Wired into the
+  architect + docs-index + KB (pushed to `knowledge_base`).
 - **P4 — Optional families** (#11, #13, #14, #15) as use cases emerge.
 
 ---

--- a/mcp-servers/documentation/src/docs-index/systems.ts
+++ b/mcp-servers/documentation/src/docs-index/systems.ts
@@ -16,6 +16,9 @@ export const SYSTEMS_TECHNOLOGIES = [
   "hardware-aware-design",
   "data-intensive",
   "security-architecture",
+  "distributed-ledger",
+  "cyber-physical",
+  "game-engine-architecture",
 ] as const;
 
 export const systemsDocs: DocsRecord = {
@@ -71,6 +74,24 @@ export const systemsDocs: DocsRecord = {
     "threat-modeling": {
       local: "security-architecture/threat-modeling.md",
       url: "https://owasp.org/www-community/Threat_Modeling",
+    },
+  },
+  "distributed-ledger": {
+    "ledger-architecture": {
+      local: "distributed-ledger/ledger-architecture.md",
+      url: "https://ethereum.org/en/developers/docs/scaling/",
+    },
+  },
+  "cyber-physical": {
+    "ics-architecture": {
+      local: "cyber-physical/ics-architecture.md",
+      url: "https://www.isa.org/standards-and-publications/isa-standards/isa-iec-62443-series-of-standards",
+    },
+  },
+  "game-engine-architecture": {
+    "engine-architecture": {
+      local: "game-engine-architecture/engine-architecture.md",
+      url: "https://www.gameenginebook.com/",
     },
   },
 };

--- a/skills/systems/cyber-physical/SKILL.md
+++ b/skills/systems/cyber-physical/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: cyber-physical
+description: |
+  Cyber-physical / industrial control system (ICS-SCADA) architecture in general:
+  the Purdue model levels, control loops, IT/OT convergence, OT security
+  (IEC 62443, segmentation, zero-trust for OT), safety, determinism, and
+  redundancy. Architect-level, beyond any specific DCS/PLC product.
+
+  USE WHEN: designing/evaluating industrial control, SCADA, robotics, energy,
+  automotive, or IoT-at-scale systems, "OT security", "Purdue model", "PLC/RTU/
+  SCADA architecture", "IT/OT convergence", "IEC 62443", "control loop", safety
+  instrumented systems.
+
+  DO NOT USE FOR: specific DCS platforms / IEC 61131 / ISA formats (use the
+  `industrial/*` skills); pure RTOS scheduling (use `embedded-rtos`); app
+  security (use `security-architecture`).
+allowed-tools: Read, Grep, Glob
+---
+# Cyber-Physical / ICS-SCADA Architecture (general)
+
+Generalizes the product-specific `industrial/*` skills (DCS, IEC 61131, ISA) into
+engine-agnostic control-system design. A cyber-physical system couples
+**computation with physical processes** through sensors and actuators in
+closed control loops, where a software fault can have physical consequences.
+
+## The Purdue reference model (segment by level)
+
+```
+L5/4  Enterprise / MES / ERP         (IT)
+------------------- IT/OT boundary (DMZ) -------------------
+L3    Operations / historians / engineering workstations
+L2    SCADA / HMI / supervisory control
+L1    Controllers: PLC / RTU / DCS
+L0    Field devices: sensors, actuators, drives  (physical process)
+```
+
+Architecture is organized by these levels; the **IT/OT boundary** is the
+critical trust boundary to design and defend.
+
+## Defining constraints
+
+- **Determinism & real-time**: control loops have hard cycle times and deadlines
+  (see `embedded-rtos`); jitter degrades control.
+- **Safety**: safety-instrumented systems (SIS) are separated from control;
+  fail-safe/fail-operational design, redundancy (TMR), and standards like
+  IEC 61508 / 61511.
+- **Availability over confidentiality**: unlike IT, OT prioritizes uptime and
+  safety — you cannot just patch/reboot a running plant.
+
+## OT security (IT/OT convergence)
+
+- The **air gap is largely a myth** now — connectivity for analytics/remote ops
+  is pervasive. Design for it.
+- **IEC 62443** is the reference standard. Apply **zone-and-conduit
+  segmentation**, an IT/OT DMZ, least-privilege, and increasingly **zero-trust
+  for OT** (authenticate every cross-zone flow). Pairs with
+  `security-architecture`.
+- Legacy devices have weak/no auth → compensate with network segmentation,
+  monitoring, and protocol-aware firewalls rather than assuming endpoint security.
+
+## Guidance
+Treat the IT/OT boundary as the primary trust boundary; segment by Purdue level;
+keep safety functions independent and redundant; design for determinism and
+availability first; and assume connectivity — secure it (IEC 62443) rather than
+relying on isolation.

--- a/skills/systems/distributed-ledger/SKILL.md
+++ b/skills/systems/distributed-ledger/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: distributed-ledger
+description: |
+  Distributed-ledger / blockchain architecture in general (engine-agnostic):
+  when a ledger beats a database, consensus families (PoW/PoS/BFT), L1 vs L2
+  (rollups, channels, sidechains), permissioned vs permissionless, UTXO vs
+  account models, and the scalability trilemma. Architect-level, not coin-specific.
+
+  USE WHEN: designing/evaluating a blockchain or DLT system in general, "L2",
+  "rollup", "zk vs optimistic", "PoS vs PoW", "permissioned ledger", "consortium
+  chain", "UTXO vs account", "do we even need a blockchain", token/state design.
+
+  DO NOT USE FOR: Bitcoin-specific work (use the `bitcoin/*` skills); raw
+  consensus internals (use `distributed-consensus`); ordinary app data (use
+  database / data-intensive skills).
+allowed-tools: Read, Grep, Glob
+---
+# Distributed-Ledger Architecture (general)
+
+Generalizes the Bitcoin-specific `bitcoin/*` skills into engine-agnostic ledger
+design. For deep Bitcoin/Lightning specifics, defer to those skills.
+
+## First question: do you actually need a ledger?
+
+A ledger is an **append-only, replicated, tamper-evident** log agreed by
+mutually-distrusting parties. Use one only when you genuinely have:
+multi-party **lack of trust**, a need for **shared auditable state**, and no
+acceptable trusted intermediary. **If a single org controls the data, a normal
+(possibly append-only/audited) database is simpler, faster, and cheaper** — most
+"blockchain" projects should be databases.
+
+## Consensus family (builds on `distributed-consensus`)
+
+| Family | Sybil resistance | Trade-off |
+|--------|------------------|-----------|
+| **PoW** | Burn energy | Robust, slow, energy-heavy, probabilistic finality |
+| **PoS** | Stake capital | Efficient, fast finality, weak-subjectivity/validator-set concerns |
+| **BFT (PBFT/Tendermint)** | Known validator set | Fast deterministic finality, bounded validators → more permissioned |
+
+Permissionless (open validator set) favors PoW/PoS; permissioned/consortium
+favors BFT.
+
+## Layering: L1 vs L2
+
+- **L1** = base chain (security + data availability). Scaling it directly hits
+  the trilemma.
+- **L2** moves execution off L1 while inheriting its security:
+  - **Rollups** post compressed data + proofs to L1. **ZK rollups** (validity
+    proofs, fast finality, harder to build) vs **optimistic rollups** (fraud
+    proofs, challenge window/withdrawal delay).
+  - **State/payment channels** (e.g. Lightning) — off-chain bilateral updates,
+    on-chain settlement; great for high-frequency payments.
+  - **Sidechains** — own security, bridged; weaker guarantees.
+
+## Other decisions
+
+- **Permissioned vs permissionless**: trust model + regulatory needs.
+- **State model**: **UTXO** (parallelizable, privacy, harder smart contracts) vs
+  **account** (stateful contracts, simpler, sequential nonces).
+- **Trilemma**: decentralization / security / scalability — you optimize two;
+  L2s are the usual escape valve.
+- **Finality**: probabilistic (PoW) vs deterministic/instant (BFT) — affects UX
+  and bridge safety.
+
+## Guidance
+Single trust domain → database. Multi-party, open → permissionless L1 + L2 for
+scale. Known consortium → permissioned BFT chain. High-frequency payments →
+channels. Always justify the ledger over a database first.

--- a/skills/systems/game-engine-architecture/SKILL.md
+++ b/skills/systems/game-engine-architecture/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: game-engine-architecture
+description: |
+  Game-engine architecture, engine-agnostic: the game loop (fixed vs variable
+  timestep), ECS vs scene-graph/OOP, the render pipeline, core subsystems
+  (physics, audio, animation, assets, memory), and netcode models. Architect-
+  level, beyond any specific engine.
+
+  USE WHEN: designing/evaluating a game engine or game's architecture in general,
+  "game loop", "ECS", "entity component system", "render pipeline", "forward vs
+  deferred", "rollback netcode", "lockstep", custom engine vs off-the-shelf,
+  data-oriented game design.
+
+  DO NOT USE FOR: Unity-specific work (use the `gamedev/unity-*` skills);
+  low-level cache/SIMD detail (use `hardware-aware-design`); web graphics (use
+  graphics skills).
+allowed-tools: Read, Grep, Glob
+---
+# Game-Engine Architecture (engine-agnostic)
+
+Generalizes the Unity-specific `gamedev/*` skills into engine-agnostic design.
+For Unity APIs/DOTS specifics, defer to those skills.
+
+## The game loop
+
+The heartbeat: process input → update simulation → render. Key decision is the
+timestep:
+- **Fixed timestep** for the simulation (deterministic physics, stable netcode),
+  **decoupled** from a variable render rate with interpolation. This is the
+  standard for anything needing determinism (multiplayer, physics).
+- Variable timestep is simpler but makes physics/netcode non-deterministic.
+
+## Data model: ECS vs scene-graph/OOP
+
+| | OOP / scene graph | **ECS** (entity-component-system) |
+|---|---|---|
+| Layout | Objects with inheritance | Data in contiguous component arrays |
+| Cache | Pointer-chasing, poor | Data-oriented, cache-friendly, SIMD-able |
+| Logic | Methods on objects | Systems iterate components |
+| Fits | Small/simple games, editor tooling | Many entities, performance, parallelism |
+
+ECS is the modern default for performance and parallelism (see
+`hardware-aware-design`); OOP scene graphs remain fine for simpler titles.
+
+## Render pipeline
+
+- **Forward** (shade per object) vs **deferred** (G-buffer, shade per pixel —
+  many lights) vs forward+ / clustered. Choose by light count and platform
+  (mobile/bandwidth favors forward/tiled).
+- A **render graph / frame graph** declares passes + resource dependencies so
+  the engine schedules and aliases GPU memory — the modern structuring approach.
+
+## Core subsystems
+
+Physics, audio, animation, scene/asset streaming, and a **memory strategy**
+(pools/arenas/frame allocators rather than per-frame malloc — determinism +
+no GC stalls). Keep subsystems decoupled behind clear interfaces.
+
+## Netcode (multiplayer)
+
+- **Lockstep** (send inputs, simulate deterministically everywhere): tiny
+  bandwidth, needs full determinism; RTS.
+- **Client prediction + server reconciliation**: responsive, authoritative
+  server; FPS.
+- **Rollback**: predict + re-simulate on correction; fighting games.
+Authority and determinism (fixed timestep) are the cross-cutting requirements.
+
+## Guidance
+Prefer off-the-shelf (Unity/Unreal/Godot) unless you have a specific reason to
+build. If custom: fixed-timestep loop, ECS for entity-heavy/perf games, a render
+graph, arena memory, and a netcode model matched to the genre.


### PR DESCRIPTION
## Summary
Workstream **P3** of the multi-domain architect plan: extract general, engine-agnostic architecture skills from existing domain-specific verticals, so the architect can reason about each domain in the abstract (not only the specific product).

- **systems/distributed-ledger** — general DLT (consensus families, L1/L2, rollups/channels, UTXO vs account, trilemma) — generalized from `bitcoin/*`.
- **systems/cyber-physical** — ICS/SCADA (Purdue model, IT/OT boundary, IEC 62443, determinism/safety) — generalized from `industrial/*`.
- **systems/game-engine-architecture** — engine-agnostic (game loop, ECS vs scene graph, render graph, netcode) — generalized from `gamedev/unity-*`.

Each is authored at architect altitude and wired into the architect's `extended_skills` (now 3 core + 37 extended, all resolve) + `docs-index/systems.ts`. Backing KB deep-dives pushed to `knowledge_base`.

## Verification
- Full server suite **1850 green**; documentation MCP builds clean.
- All architect skill references resolve.

No installer/runtime code changed — skills, architect frontmatter, docs-index, and docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)