### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #112)

### DIFF
--- a/commands/health-check.md
+++ b/commands/health-check.md
@@ -2,7 +2,7 @@
 name: health-check
 description: Run health checks on dev-suite installation
 allowed-tools: Bash
-argument-hint: [--quick] [--verbose]
+argument-hint: "[--quick] [--verbose]"
 ---
 
 # Health Check

--- a/commands/init-project.md
+++ b/commands/init-project.md
@@ -2,7 +2,7 @@
 name: init-project
 description: Initialize dev-suite for a project using the web dashboard.
 allowed-tools: Bash
-argument-hint: [project-path]
+argument-hint: "[project-path]"
 ---
 
 # /init-project - Initialize dev-suite

--- a/commands/release-promote.md
+++ b/commands/release-promote.md
@@ -2,7 +2,7 @@
 name: release-promote
 description: Generate all promotional content for a new dev-suite release across every channel
 allowed-tools: Read, Write, Bash, Glob
-argument-hint: [version] — e.g. /release-promote v1.2.0
+argument-hint: "[version] — e.g. /release-promote v1.2.0"
 ---
 
 # Release Promote

--- a/commands/uninstall-dev-suite.md
+++ b/commands/uninstall-dev-suite.md
@@ -2,7 +2,7 @@
 name: uninstall-dev-suite
 description: Remove dev-suite components from a project. Only removes tracked components, preserves user content.
 allowed-tools: Bash, Read, Glob, AskUserQuestion
-argument-hint: [project-path]
+argument-hint: "[project-path]"
 ---
 
 # Uninstall Dev-Suite Command

--- a/commands/uninstall.md
+++ b/commands/uninstall.md
@@ -2,7 +2,7 @@
 name: uninstall
 description: Alias for /uninstall-dev-suite. Removes dev-suite components preserving user content.
 allowed-tools: Bash, Read, Glob, AskUserQuestion
-argument-hint: [project-path]
+argument-hint: "[project-path]"
 ---
 
 # Uninstall Dev-Suite


### PR DESCRIPTION
Closes #112.

## Summary

Purely mechanical single-character transform to 5 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (5)

- `commands/health-check.md`
- `commands/uninstall.md`
- `commands/uninstall-dev-suite.md`
- `commands/release-promote.md`
- `commands/init-project.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
