### PR TITLE
ci: validate component frontmatter with a real YAML parser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Validate component catalog
         run: node scripts/validate-catalog.mjs
 
+      - name: Validate component frontmatter
+        run: node scripts/validate-frontmatter.mjs
+
       - name: Check shared type sync
         run: node scripts/check-type-sync.mjs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Five commands are no longer dropped by strict frontmatter parsers.**
+  `argument-hint` was written with bare brackets, which YAML does not read as
+  the documented string: `[project-path]` parses as the array
+  `["project-path"]` (`init-project`, `uninstall`, `uninstall-dev-suite`),
+  while `[--quick] [--verbose]` and `[version] — e.g. ...` are a flow sequence
+  followed by trailing content — invalid YAML that makes the *entire*
+  frontmatter block throw, taking `name`, `description` and `allowed-tools`
+  down with it (`health-check`, `release-promote`). Claude Code tolerated both
+  shapes, so this stayed invisible until GitHub Copilot CLI ≥1.0.65 tightened
+  its type check and silently stopped listing the commands. All five values are
+  now quoted. Reported and fixed by @thejesh23 in #112 / #113.
+
+### Added
+
+- **`scripts/validate-frontmatter.mjs` — frontmatter validity check, run in
+  CI.** Parses every frontmatter block under `agents/`, `commands/` and
+  `skills/` with `gray-matter` (the same parser the dashboard uses at runtime),
+  and fails on YAML that does not parse, on missing `name` / `description`, and
+  on keys whose type doesn't match the documented one — the `argument-hint`
+  array above included. `scripts/validate-catalog.mjs` could not catch this
+  class of bug: it reads frontmatter with a line-oriented regex that accepts
+  YAML a real parser rejects, and it only walks `agents/`.
+
 ## [1.12.0] - 2026-07-02
 
 ### Fixed

--- a/scripts/validate-frontmatter.mjs
+++ b/scripts/validate-frontmatter.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+/**
+ * Validates YAML frontmatter across agents/, commands/ and skills/ using the
+ * same parser the product uses (gray-matter, which wraps js-yaml).
+ *
+ * This exists because frontmatter that Claude Code tolerates can still be
+ * invalid YAML, and stricter downstream consumers then drop the component
+ * silently. The canonical example (issue #112) is:
+ *
+ *   argument-hint: [--quick] [--verbose]   # flow sequence + trailing content
+ *                                          # => YAML parse error, whole block lost
+ *   argument-hint: [project-path]          # => array, not the documented string
+ *   argument-hint: "[--quick] [--verbose]" # => correct
+ *
+ * scripts/validate-catalog.mjs cannot catch this: it parses frontmatter with a
+ * line-oriented regex that happily "reads" YAML a real parser rejects, and it
+ * only walks agents/. Every check here therefore goes through a real parser.
+ *
+ * Rules:
+ *   1. A file whose content starts with `---` must have frontmatter that parses.
+ *   2. Frontmatter must be a mapping with `name` and `description`.
+ *   3. Known keys must hold the documented type (see KEY_TYPES).
+ *   4. Unknown keys warn rather than fail, so new fields aren't blocked here.
+ *
+ * Files without frontmatter (READMEs, skill quick-ref pages) are skipped.
+ *
+ * Exits non-zero and prints every violation when frontmatter is invalid.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SCAN_DIRS = ['agents', 'commands', 'skills'];
+
+// Documented type for each known frontmatter key. 'string[]' means a sequence
+// whose every entry is a string.
+const KEY_TYPES = {
+  name: 'string',
+  description: 'string',
+  model: 'string',
+  'allowed-tools': 'string',
+  'argument-hint': 'string',
+  skills: 'string[]',
+  core_skills: 'string[]',
+  extended_skills: 'string[]',
+  mcp_servers: 'string[]',
+  'disable-model-invocation': 'boolean',
+  'user-invocable': 'boolean',
+};
+
+const REQUIRED_KEYS = ['name', 'description'];
+
+const errors = [];
+const warnings = [];
+
+function err(msg) {
+  errors.push(msg);
+}
+function warn(msg) {
+  warnings.push(msg);
+}
+
+// gray-matter is a dependency of the dashboard server, not of this repo root.
+// Resolving it from there keeps validation on the exact parser that consumes
+// these files at runtime.
+const serverPkg = path.join(ROOT, 'configurator/dashboard/server/package.json');
+let matter;
+try {
+  matter = createRequire(serverPkg)('gray-matter');
+} catch {
+  console.error(
+    'ERROR gray-matter could not be resolved from configurator/dashboard/server.\n' +
+      '      Run `npm ci` in configurator/dashboard/server before this script.'
+  );
+  process.exit(1);
+}
+
+function typeOf(value) {
+  if (Array.isArray(value)) return 'array';
+  if (value === null) return 'null';
+  return typeof value;
+}
+
+function describe(value) {
+  const json = JSON.stringify(value);
+  return json === undefined ? String(value) : json;
+}
+
+function checkType(rel, key, value) {
+  const expected = KEY_TYPES[key];
+  if (!expected) {
+    warn(`${rel}: unknown frontmatter key "${key}"`);
+    return;
+  }
+
+  if (expected === 'string[]') {
+    if (!Array.isArray(value)) {
+      err(`${rel}: "${key}" must be a list, got ${typeOf(value)} ${describe(value)}`);
+      return;
+    }
+    for (const item of value) {
+      if (typeof item !== 'string') {
+        err(`${rel}: "${key}" must contain only strings, got ${typeOf(item)} ${describe(item)}`);
+      }
+    }
+    return;
+  }
+
+  if (typeOf(value) !== expected) {
+    const hint =
+      expected === 'string' && Array.isArray(value)
+        ? ' — wrap the value in double quotes so YAML reads it as a string'
+        : '';
+    err(`${rel}: "${key}" must be a ${expected}, got ${typeOf(value)} ${describe(value)}${hint}`);
+  }
+}
+
+const mdFiles = [];
+for (const dir of SCAN_DIRS) {
+  const full = path.join(ROOT, dir);
+  if (!fs.existsSync(full)) continue;
+  (function walk(current) {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const child = path.join(current, entry.name);
+      if (entry.isDirectory()) walk(child);
+      else if (entry.name.endsWith('.md')) mdFiles.push(child);
+    }
+  })(full);
+}
+
+let checked = 0;
+for (const file of mdFiles) {
+  const rel = path.relative(ROOT, file).replace(/\\/g, '/');
+  const raw = fs.readFileSync(file, 'utf-8');
+  if (!/^---\r?\n/.test(raw)) continue; // no frontmatter block — nothing to validate
+
+  let data;
+  try {
+    data = matter(raw).data;
+  } catch (e) {
+    err(`${rel}: frontmatter is not valid YAML (${e.message.split('\n')[0]})`);
+    continue;
+  }
+
+  if (typeOf(data) !== 'object' || Object.keys(data).length === 0) {
+    err(`${rel}: frontmatter must be a non-empty mapping`);
+    continue;
+  }
+
+  checked++;
+  for (const key of REQUIRED_KEYS) {
+    if (!(key in data)) err(`${rel}: frontmatter is missing required "${key}"`);
+  }
+  for (const [key, value] of Object.entries(data)) {
+    checkType(rel, key, value);
+  }
+}
+
+for (const w of warnings) console.warn(`WARN  ${w}`);
+if (errors.length > 0) {
+  for (const e of errors) console.error(`ERROR ${e}`);
+  console.error(`\nFrontmatter validation failed with ${errors.length} error(s).`);
+  process.exit(1);
+}
+console.log(
+  `Frontmatter OK: ${checked} file(s) with frontmatter across ${SCAN_DIRS.join(', ')}, ${warnings.length} warning(s).`
+);


### PR DESCRIPTION
Follow-up to #112 / #113.

## Why

#113 fixed the five broken `argument-hint` values. This adds the check that would have caught them, because nothing in the repo could.

The impact was worse than the issue reported. Run through `gray-matter@^4.0.3` — a parser dev-suite **already depends on** — three of the five parse as arrays, but two **throw**:

| File | Result before #113 |
|---|---|
| `init-project`, `uninstall`, `uninstall-dev-suite` | array `["project-path"]` |
| `health-check` | **parse error** — `can not read an implicit mapping pair` |
| `release-promote` | **parse error** — `a multiline key may not be an implicit key` |

`[--quick] [--verbose]` isn't a one-element array — it's a flow sequence followed by trailing content, which is invalid YAML. A parse error kills the **entire frontmatter block**, so a strict consumer loses `name`, `description` and `allowed-tools` for those two commands, not just `argument-hint`.

## Why the existing checks missed it

`scripts/validate-catalog.mjs` cannot catch this class of bug by construction:

1. It parses frontmatter with a hand-rolled line regex (`validate-catalog.mjs:45`) that happily "reads" YAML a real parser rejects.
2. It only walks `agents/` — never `commands/` or `skills/`.

## What this adds

`scripts/validate-frontmatter.mjs`, wired into CI after the catalog check. It parses every frontmatter block under `agents/`, `commands/` and `skills/` with `gray-matter` (the same parser the dashboard uses at runtime) and fails on:

- frontmatter that doesn't parse as YAML
- missing `name` / `description`
- a known key whose type doesn't match the documented one (with a fix hint: *wrap the value in double quotes*)

Unknown keys warn rather than fail, so new fields aren't blocked.

The enforced type map isn't invented — it's derived from every frontmatter block in the catalog, so it encodes existing reality rather than an aspiration.

## Verification

Both directions, which matters more than the check merely existing:

```
# pre-#113 tree
ERROR commands/health-check.md: frontmatter is not valid YAML (can not read an implicit mapping pair...)
ERROR commands/init-project.md: "argument-hint" must be a string, got array ["project-path"] — wrap the value in double quotes...
ERROR commands/release-promote.md: frontmatter is not valid YAML (a multiline key may not be an implicit key...)
ERROR commands/uninstall-dev-suite.md: "argument-hint" must be a string, got array ["project-path"] ...
ERROR commands/uninstall.md: "argument-hint" must be a string, got array ["project-path"] ...
Frontmatter validation failed with 5 error(s).   # exit 1

# post-#113 tree
Frontmatter OK: 779 file(s) with frontmatter across agents, commands, skills, 0 warning(s).   # exit 0
```

Zero false positives across all 779 files carrying frontmatter.

## Note on the dependency

`gray-matter` is resolved from `configurator/dashboard/server` via `createRequire` — this repo has no root `package.json`, and `js-yaml` is only a transitive dep there (via gray-matter), so depending on it directly would be depending on something undeclared. The CI step is ordered after that workspace's `npm ci`, and the script exits with an actionable message if resolution fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)