### PR TITLE
fix(documentation): index the remaining 70 orphaned KB docs; fix 10 ghost technologies

### DIFF
--- a/mcp-servers/documentation/src/docs-index/ai.ts
+++ b/mcp-servers/documentation/src/docs-index/ai.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 /**
  * AI integration documentation
- * Includes: RAG patterns, Vector databases
+ * Includes: RAG patterns, Vector databases, Claude API, MCP SDK
  */
 
 import type { DocsRecord } from "./types.js";
@@ -9,6 +9,8 @@ import type { DocsRecord } from "./types.js";
 export const AI_TECHNOLOGIES = [
   "rag-patterns",
   "vector-databases",
+  "anthropic",
+  "mcp-sdk",
 ] as const;
 
 export const aiDocs: DocsRecord = {
@@ -55,6 +57,60 @@ export const aiDocs: DocsRecord = {
     indexing: {
       local: "vector-databases/indexing.md",
       url: "https://www.pinecone.io/learn/vector-database/",
+    },
+  },
+
+  // Canonical host is platform.claude.com: both docs.anthropic.com and
+  // docs.claude.com now 301 there.
+  anthropic: {
+    basics: {
+      local: "anthropic/basics.md",
+      url: "https://platform.claude.com/docs/en/api/getting-started",
+    },
+    messages: {
+      local: "anthropic/messages.md",
+      url: "https://platform.claude.com/docs/en/api/messages",
+    },
+    streaming: {
+      local: "anthropic/streaming.md",
+      url: "https://platform.claude.com/docs/en/api/messages-streaming",
+    },
+    tools: {
+      local: "anthropic/tools.md",
+      url: "https://platform.claude.com/docs/en/docs/build-with-claude/tool-use/overview",
+    },
+    // Batches + prompt caching + token counting + retries: no single upstream
+    // page covers them, so this points at the features hub that indexes them.
+    advanced: {
+      local: "anthropic/advanced.md",
+      url: "https://platform.claude.com/docs/en/build-with-claude/overview",
+    },
+  },
+
+  "mcp-sdk": {
+    basics: {
+      local: "mcp-sdk/basics.md",
+      url: "https://modelcontextprotocol.io/docs/concepts/architecture",
+    },
+    server: {
+      local: "mcp-sdk/server.md",
+      url: "https://modelcontextprotocol.io/docs/develop/build-server",
+    },
+    client: {
+      local: "mcp-sdk/client.md",
+      url: "https://modelcontextprotocol.io/docs/develop/build-client",
+    },
+    tools: {
+      local: "mcp-sdk/tools.md",
+      url: "https://modelcontextprotocol.io/docs/concepts/tools",
+    },
+    resources: {
+      local: "mcp-sdk/resources.md",
+      url: "https://modelcontextprotocol.io/docs/concepts/resources",
+    },
+    prompts: {
+      local: "mcp-sdk/prompts.md",
+      url: "https://modelcontextprotocol.io/docs/concepts/prompts",
     },
   },
 };

--- a/mcp-servers/documentation/src/docs-index/api.ts
+++ b/mcp-servers/documentation/src/docs-index/api.ts
@@ -26,6 +26,10 @@ export const API_TECHNOLOGIES = [
 
 export const apiDocs: DocsRecord = {
   graphql: {
+    basics: {
+      local: "graphql/basics.md",
+      url: "https://graphql.org/learn/",
+    },
     schema: {
       local: "graphql/schema.md",
       url: "https://graphql.org/learn/schema/",
@@ -33,6 +37,16 @@ export const apiDocs: DocsRecord = {
     resolvers: {
       local: "graphql/resolvers.md",
       url: "https://graphql.org/learn/execution/",
+    },
+    // The KB file is "GraphQL Serving over HTTP" — kept keyed to its file
+    // stem for consistency with the rest of the index.
+    controllers: {
+      local: "graphql/controllers.md",
+      url: "https://graphql.org/learn/serving-over-http/",
+    },
+    "data-fetching": {
+      local: "graphql/data-fetching.md",
+      url: "https://graphql.org/learn/queries/",
     },
   },
 

--- a/mcp-servers/documentation/src/docs-index/backend.ts
+++ b/mcp-servers/documentation/src/docs-index/backend.ts
@@ -108,6 +108,53 @@ export const backendDocs: DocsRecord = {
     },
   },
 
+  // fastify and hono were listed in BACKEND_TECHNOLOGIES with no record, so
+  // every request for them errored: git mode found no KB directory and live
+  // mode had no entry to read a url from. No KB content exists for either —
+  // these entries make them live-only, which is how the index already treats
+  // technologies the KB has not covered.
+  fastify: {
+    routes: {
+      local: "fastify/routes.md",
+      url: "https://fastify.dev/docs/latest/Reference/Routes/",
+    },
+    hooks: {
+      local: "fastify/hooks.md",
+      url: "https://fastify.dev/docs/latest/Reference/Hooks/",
+    },
+    plugins: {
+      local: "fastify/plugins.md",
+      url: "https://fastify.dev/docs/latest/Reference/Plugins/",
+    },
+    validation: {
+      local: "fastify/validation.md",
+      url: "https://fastify.dev/docs/latest/Reference/Validation-and-Serialization/",
+    },
+    testing: {
+      local: "fastify/testing.md",
+      url: "https://fastify.dev/docs/latest/Guides/Testing/",
+    },
+  },
+
+  hono: {
+    routing: {
+      local: "hono/routing.md",
+      url: "https://hono.dev/docs/api/routing",
+    },
+    context: {
+      local: "hono/context.md",
+      url: "https://hono.dev/docs/api/context",
+    },
+    middleware: {
+      local: "hono/middleware.md",
+      url: "https://hono.dev/docs/guides/middleware",
+    },
+    testing: {
+      local: "hono/testing.md",
+      url: "https://hono.dev/docs/guides/testing",
+    },
+  },
+
   // Python frameworks
   fastapi: {
     basics: {
@@ -117,6 +164,56 @@ export const backendDocs: DocsRecord = {
     database: {
       local: "fastapi/database.md",
       url: "https://fastapi.tiangolo.com/tutorial/sql-databases/",
+    },
+  },
+
+  // django and flask: same ghost situation as fastify/hono above. The
+  // /en/stable/ paths are live aliases, so they track releases.
+  django: {
+    routing: {
+      local: "django/routing.md",
+      url: "https://docs.djangoproject.com/en/stable/topics/http/urls/",
+    },
+    models: {
+      local: "django/models.md",
+      url: "https://docs.djangoproject.com/en/stable/topics/db/models/",
+    },
+    templates: {
+      local: "django/templates.md",
+      url: "https://docs.djangoproject.com/en/stable/topics/templates/",
+    },
+    testing: {
+      local: "django/testing.md",
+      url: "https://docs.djangoproject.com/en/stable/topics/testing/",
+    },
+    deployment: {
+      local: "django/deployment.md",
+      url: "https://docs.djangoproject.com/en/stable/howto/deployment/",
+    },
+  },
+
+  // Flask has no dedicated routing page — routing, url_for and request
+  // handling all live in Quickstart, so that is the topic key.
+  flask: {
+    quickstart: {
+      local: "flask/quickstart.md",
+      url: "https://flask.palletsprojects.com/en/stable/quickstart/",
+    },
+    blueprints: {
+      local: "flask/blueprints.md",
+      url: "https://flask.palletsprojects.com/en/stable/blueprints/",
+    },
+    templates: {
+      local: "flask/templates.md",
+      url: "https://flask.palletsprojects.com/en/stable/templating/",
+    },
+    testing: {
+      local: "flask/testing.md",
+      url: "https://flask.palletsprojects.com/en/stable/testing/",
+    },
+    deploying: {
+      local: "flask/deploying.md",
+      url: "https://flask.palletsprojects.com/en/stable/deploying/",
     },
   },
 
@@ -217,6 +314,32 @@ export const backendDocs: DocsRecord = {
     basics: {
       local: "mapstruct/basics.md",
       url: "https://mapstruct.org/documentation/stable/reference/html/",
+    },
+    cheatsheet: {
+      local: "mapstruct/quick-ref/cheatsheet.md",
+      url: "https://mapstruct.org/documentation/stable/reference/html/",
+    },
+    "advanced-patterns": {
+      local: "mapstruct/deep-docs/advanced-patterns.md",
+      url: "https://mapstruct.org/documentation/stable/reference/html/#_advanced_mapping_options",
+    },
+    "spring-boot-integration": {
+      local: "mapstruct/deep-docs/spring-boot-integration.md",
+      url: "https://mapstruct.org/documentation/stable/reference/html/#using-dependency-injection",
+    },
+  },
+
+  thymeleaf: {
+    "email-templates": {
+      local: "thymeleaf/deep-docs/email-templates.md",
+      url: "https://www.thymeleaf.org/doc/articles/springmail.html",
+    },
+  },
+
+  "apache-poi": {
+    "excel-export-service": {
+      local: "apache-poi/deep-docs/excel-export-service.md",
+      url: "https://poi.apache.org/components/spreadsheet/quick-guide.html",
     },
   },
 

--- a/mcp-servers/documentation/src/docs-index/databases.ts
+++ b/mcp-servers/documentation/src/docs-index/databases.ts
@@ -24,6 +24,15 @@ export const DATABASE_TECHNOLOGIES = [
   "spring-data-elasticsearch",
   "spring-data-neo4j",
   "spring-data-jdbc",
+  // SQL dialects & procedural languages
+  "sql-fundamentals",
+  "oracle",
+  "plsql",
+  "plpgsql",
+  "sqlserver",
+  "tsql",
+  // Schema migrations
+  "migrations",
 ] as const;
 
 export const databaseDocs: DocsRecord = {
@@ -266,6 +275,67 @@ export const databaseDocs: DocsRecord = {
     events: {
       local: "spring-data-jdbc/events.md",
       url: "https://docs.spring.io/spring-data/jdbc/reference/jdbc/entity-callbacks.html",
+    },
+  },
+
+  // The KB's SQL material is nominally vendor-neutral but its examples are
+  // PostgreSQL-flavoured (DISTINCT ON, ON CONFLICT, RETURNING), so the
+  // PostgreSQL manual is the honest upstream anchor here.
+  "sql-fundamentals": {
+    basics: {
+      local: "sql-fundamentals/basics.md",
+      url: "https://www.postgresql.org/docs/current/queries.html",
+    },
+    transactions: {
+      local: "sql-fundamentals/transactions.md",
+      url: "https://www.postgresql.org/docs/current/mvcc.html",
+    },
+  },
+
+  oracle: {
+    basics: {
+      local: "oracle/basics.md",
+      url: "https://docs.oracle.com/en/database/oracle/oracle-database/23/cncpt/index.html",
+    },
+  },
+
+  plsql: {
+    basics: {
+      local: "plsql/basics.md",
+      url: "https://docs.oracle.com/en/database/oracle/oracle-database/23/lnpls/index.html",
+    },
+  },
+
+  plpgsql: {
+    basics: {
+      local: "plpgsql/basics.md",
+      url: "https://www.postgresql.org/docs/current/plpgsql.html",
+    },
+  },
+
+  sqlserver: {
+    basics: {
+      local: "sqlserver/basics.md",
+      url: "https://learn.microsoft.com/en-us/sql/sql-server/",
+    },
+  },
+
+  tsql: {
+    basics: {
+      local: "tsql/basics.md",
+      url: "https://learn.microsoft.com/en-us/sql/t-sql/language-reference",
+    },
+  },
+
+  // Weak anchor, deliberately: the KB article is tool-agnostic (Flyway,
+  // Liquibase, Alembic, Prisma Migrate and Rails all get roughly equal
+  // billing) and most of it is vendor-neutral technique — expand/contract,
+  // lock-free index builds, batch migrations. Flyway is the tool its own
+  // examples use, so it is the closest thing to an upstream owner.
+  migrations: {
+    basics: {
+      local: "migrations/basics.md",
+      url: "https://documentation.red-gate.com/flyway",
     },
   },
 };

--- a/mcp-servers/documentation/src/docs-index/frontend.ts
+++ b/mcp-servers/documentation/src/docs-index/frontend.ts
@@ -22,6 +22,8 @@ export const FRONTEND_TECHNOLOGIES = [
   "shadcn",
   "skeleton",
   "ngrx",
+  "radix-ui",
+  "streamlit",
 ] as const;
 
 export const frontendDocs: DocsRecord = {
@@ -229,6 +231,71 @@ export const frontendDocs: DocsRecord = {
     "component-store": {
       local: "ngrx/component-store.md",
       url: "https://ngrx.io/guide/component-store",
+    },
+  },
+
+  // `svelte` was listed in FRONTEND_TECHNOLOGIES with no record: the KB's
+  // svelte/sveltekit.md is served under the separate `sveltekit` key, which
+  // left svelte/runes.md — a Svelte language feature, not a SvelteKit one —
+  // with no way to reach it.
+  svelte: {
+    runes: {
+      local: "svelte/runes.md",
+      url: "https://svelte.dev/docs/svelte/what-are-runes",
+    },
+  },
+
+  // `solid` was another record-less entry; no KB content, so live-only.
+  solid: {
+    signals: {
+      local: "solid/signals.md",
+      url: "https://docs.solidjs.com/concepts/signals",
+    },
+    effects: {
+      local: "solid/effects.md",
+      url: "https://docs.solidjs.com/concepts/effects",
+    },
+    stores: {
+      local: "solid/stores.md",
+      url: "https://docs.solidjs.com/concepts/stores",
+    },
+    routing: {
+      local: "solid/routing.md",
+      url: "https://docs.solidjs.com/guides/routing-and-navigation",
+    },
+    "data-fetching": {
+      local: "solid/data-fetching.md",
+      url: "https://docs.solidjs.com/guides/fetching-data",
+    },
+  },
+
+  "radix-ui": {
+    components: {
+      local: "radix-ui/quick-ref/components.md",
+      url: "https://www.radix-ui.com/primitives/docs/overview/introduction",
+    },
+    "accessibility-patterns": {
+      local: "radix-ui/deep-docs/accessibility-patterns.md",
+      url: "https://www.radix-ui.com/primitives/docs/overview/accessibility",
+    },
+  },
+
+  streamlit: {
+    basics: {
+      local: "streamlit/basics.md",
+      url: "https://docs.streamlit.io/get-started/fundamentals/main-concepts",
+    },
+    components: {
+      local: "streamlit/components.md",
+      url: "https://docs.streamlit.io/develop/api-reference",
+    },
+    pages: {
+      local: "streamlit/pages.md",
+      url: "https://docs.streamlit.io/develop/concepts/multipage-apps/overview",
+    },
+    state: {
+      local: "streamlit/state.md",
+      url: "https://docs.streamlit.io/develop/concepts/architecture/session-state",
     },
   },
 };

--- a/mcp-servers/documentation/src/docs-index/index.ts
+++ b/mcp-servers/documentation/src/docs-index/index.ts
@@ -8,6 +8,7 @@
 
 // Re-export types
 export type { DocEntry, DocsRecord } from "./types.js";
+import type { DocsRecord } from "./types.js";
 
 // Import all categories
 import { FRONTEND_TECHNOLOGIES, frontendDocs } from "./frontend.js";
@@ -43,6 +44,7 @@ import { GAMEDEV_2D_ART_TECHNOLOGIES, gamedev2dArtDocs } from "./gamedev-2d-art.
 import { BITCOIN_TECHNOLOGIES, bitcoinDocs } from "./bitcoin.js";
 // Windows kernel & user-mode driver development
 import { WINDOWS_DRIVERS_TECHNOLOGIES, windowsDriversDocs } from "./windows-drivers.js";
+import { INDUSTRIAL_TECHNOLOGIES, industrialDocs } from "./industrial.js";
 // Low-level / systems & AI-integrated systems architecture
 import { SYSTEMS_TECHNOLOGIES, systemsDocs } from "./systems.js";
 import { AI_SYSTEMS_TECHNOLOGIES, aiSystemsDocs } from "./ai-systems.js";
@@ -81,6 +83,7 @@ export { GAMEDEV_2D_ART_TECHNOLOGIES, gamedev2dArtDocs } from "./gamedev-2d-art.
 export { BITCOIN_TECHNOLOGIES, bitcoinDocs } from "./bitcoin.js";
 // Windows kernel & user-mode driver development
 export { WINDOWS_DRIVERS_TECHNOLOGIES, windowsDriversDocs } from "./windows-drivers.js";
+export { INDUSTRIAL_TECHNOLOGIES, industrialDocs } from "./industrial.js";
 // Low-level / systems & AI-integrated systems architecture
 export { SYSTEMS_TECHNOLOGIES, systemsDocs } from "./systems.js";
 export { AI_SYSTEMS_TECHNOLOGIES, aiSystemsDocs } from "./ai-systems.js";
@@ -123,6 +126,7 @@ export const SUPPORTED_TECHNOLOGIES = [
   ...BITCOIN_TECHNOLOGIES,
   // Windows drivers
   ...WINDOWS_DRIVERS_TECHNOLOGIES,
+  ...INDUSTRIAL_TECHNOLOGIES,
   // Low-level / systems & AI-integrated systems
   ...SYSTEMS_TECHNOLOGIES,
   ...AI_SYSTEMS_TECHNOLOGIES,
@@ -134,7 +138,7 @@ export type Technology = (typeof SUPPORTED_TECHNOLOGIES)[number];
  * Combined documentation index
  * Merges all category docs into a single record for backward compatibility
  */
-export const docsIndex: Record<string, Record<string, { local: string; url: string }>> = {
+export const docsIndex: DocsRecord = {
   ...frontendDocs,
   ...metaFrameworkDocs,
   ...desktopDocs,
@@ -168,6 +172,8 @@ export const docsIndex: Record<string, Record<string, { local: string; url: stri
   ...bitcoinDocs,
   // Windows drivers
   ...windowsDriversDocs,
+  // Industrial automation / DCS
+  ...industrialDocs,
   // Low-level / systems & AI-integrated systems
   ...systemsDocs,
   ...aiSystemsDocs,
@@ -205,6 +211,7 @@ export const CATEGORY_MAP: Record<string, readonly string[]> = {
   "gamedev-2d-art": GAMEDEV_2D_ART_TECHNOLOGIES,
   bitcoin: BITCOIN_TECHNOLOGIES,
   "windows-drivers": WINDOWS_DRIVERS_TECHNOLOGIES,
+  industrial: INDUSTRIAL_TECHNOLOGIES,
   systems: SYSTEMS_TECHNOLOGIES,
   "ai-systems": AI_SYSTEMS_TECHNOLOGIES,
 };

--- a/mcp-servers/documentation/src/docs-index/industrial.ts
+++ b/mcp-servers/documentation/src/docs-index/industrial.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+/**
+ * Industrial automation / DCS documentation index
+ *
+ * Covers distributed control systems (ABB Freelance, Siemens SIMATIC PCS 7,
+ * Emerson DeltaV, Honeywell Experion PKS), the IEC 61131 programmable-
+ * controller standards, ISA instrumentation/alarm/batch standards, and the
+ * bulk-engineering workflow that generates controller configuration from
+ * engineering data.
+ *
+ * Two things are unusual about this domain and shape the entries below:
+ *
+ * 1. **The standards are paid.** IEC and ISA publish no free full text, so the
+ *    `url` is the official landing/abstract page for the standard. That is the
+ *    correct upstream — not a mirror, and deliberately not one of the PDF
+ *    copies floating around, which are unlicensed.
+ * 2. **Some articles have no upstream at all.** The ABB `.dmf`/`.prt` record
+ *    layouts are undocumented proprietary internals, `python-generation` is an
+ *    in-house workflow, and `dcs-platforms/overview` is a four-way vendor
+ *    comparison no vendor publishes. Those entries omit `url` rather than
+ *    point at a loosely-related product page: they are served from the KB or
+ *    not at all.
+ */
+
+import type { DocsRecord } from "./types.js";
+
+export const INDUSTRIAL_TECHNOLOGIES = [
+  "abb-freelance",
+  "dcs-platforms",
+  "iec61131",
+  "isa-standards",
+  "bulk-engineering",
+] as const;
+
+export const industrialDocs: DocsRecord = {
+  "abb-freelance": {
+    overview: {
+      local: "abb-freelance/overview.md",
+      url: "https://new.abb.com/control-systems/essential-automation/freelance",
+    },
+    // No url: ABB has never published the .dmf/.prt record layouts. They are
+    // written and read only by Control Builder F, and the KB articles are
+    // reverse-engineered field knowledge.
+    "dmf-format": {
+      local: "abb-freelance/dmf-format.md",
+    },
+    "prt-format": {
+      local: "abb-freelance/prt-format.md",
+    },
+  },
+
+  "dcs-platforms": {
+    // No url: an author-written ABB/Siemens/Emerson/Honeywell comparison. No
+    // vendor publishes a neutral four-way comparison, and picking one vendor's
+    // page would misrepresent the article.
+    overview: {
+      local: "dcs-platforms/overview.md",
+    },
+    siemens: {
+      local: "dcs-platforms/siemens.md",
+      url: "https://www.siemens.com/global/en/products/automation/process-control/simatic-pcs-7.html",
+    },
+    // Covers DeltaV and Experion PKS roughly equally; DeltaV is the closer fit
+    // for the article's first half.
+    "emerson-honeywell": {
+      local: "dcs-platforms/emerson-honeywell.md",
+      url: "https://www.emerson.com/en-us/automation/deltav",
+    },
+  },
+
+  // data-types and languages both document parts of the single IEC 61131-3
+  // standard, so they share its landing page.
+  iec61131: {
+    "data-types": {
+      local: "iec61131/data-types.md",
+      url: "https://webstore.iec.ch/publication/4552",
+    },
+    languages: {
+      local: "iec61131/languages.md",
+      url: "https://webstore.iec.ch/publication/4552",
+    },
+    "plcopen-xml": {
+      local: "iec61131/plcopen-xml.md",
+      url: "https://www.plcopen.org/standards/logic/iec-61131-10/",
+    },
+  },
+
+  "isa-standards": {
+    "isa-5-1": {
+      local: "isa-standards/isa-5-1.md",
+      url: "https://www.isa.org/products/ansi-isa-5-1-2024-instrumentation-and-control-symb",
+    },
+    "isa-18-101": {
+      local: "isa-standards/isa-18-101.md",
+      url: "https://www.isa.org/standards-and-publications/isa-standards/isa-standards-committees/isa18",
+    },
+    "isa-88-95": {
+      local: "isa-standards/isa-88-95.md",
+      url: "https://www.isa.org/standards-and-publications/isa-standards/isa-standards-committees/isa88",
+    },
+  },
+
+  "bulk-engineering": {
+    "namur-ne150": {
+      local: "bulk-engineering/namur-ne150.md",
+      url: "https://www.namur.net/en/publications/news-archive/ne-150-is-newly-published.html",
+    },
+    // No url: in-house generation workflow (template conventions, chunking
+    // heuristics, validation). The libraries it uses have docs; the workflow
+    // itself has no upstream owner.
+    "python-generation": {
+      local: "bulk-engineering/python-generation.md",
+    },
+  },
+};

--- a/mcp-servers/documentation/src/docs-index/languages.ts
+++ b/mcp-servers/documentation/src/docs-index/languages.ts
@@ -100,6 +100,39 @@ export const languageDocs: DocsRecord = {
     },
   },
 
+  // `python` was listed in LANGUAGE_TECHNOLOGIES with no record at all, so
+  // fetch_docs("python", …) found no entry and live mode had no url to fall
+  // back to. Git mode already served these files via the key-derived path;
+  // these entries make them work in live mode and make the topics listable.
+  // Several topics are tool-led rather than stdlib: the url follows whatever
+  // the article actually teaches.
+  python: {
+    async: {
+      local: "python/async.md",
+      url: "https://docs.python.org/3/library/asyncio.html",
+    },
+    typing: {
+      local: "python/typing.md",
+      url: "https://docs.python.org/3/library/typing.html",
+    },
+    testing: {
+      local: "python/testing.md",
+      url: "https://docs.pytest.org/en/stable/",
+    },
+    packaging: {
+      local: "python/packaging.md",
+      url: "https://docs.astral.sh/uv/",
+    },
+    quality: {
+      local: "python/quality.md",
+      url: "https://docs.astral.sh/ruff/",
+    },
+    cli: {
+      local: "python/cli.md",
+      url: "https://typer.tiangolo.com/",
+    },
+  },
+
   rust: {
     ownership: {
       local: "rust/ownership.md",
@@ -124,6 +157,10 @@ export const languageDocs: DocsRecord = {
   },
 
   go: {
+    overview: {
+      local: "go/overview.md",
+      url: "https://go.dev/doc/",
+    },
     basics: {
       local: "go/basics.md",
       url: "https://go.dev/tour/",
@@ -143,6 +180,10 @@ export const languageDocs: DocsRecord = {
     testing: {
       local: "go/testing.md",
       url: "https://go.dev/doc/tutorial/add-a-test",
+    },
+    advanced: {
+      local: "go/advanced.md",
+      url: "https://go.dev/ref/spec",
     },
   },
 

--- a/mcp-servers/documentation/src/docs-index/meta-frameworks.ts
+++ b/mcp-servers/documentation/src/docs-index/meta-frameworks.ts
@@ -48,4 +48,82 @@ export const metaFrameworkDocs: DocsRecord = {
       url: "https://kit.svelte.dev/",
     },
   },
+
+  // nuxt, remix and astro were listed in META_FRAMEWORK_TECHNOLOGIES with no
+  // record, so every request for them errored. The KB has no content for any
+  // of them; these entries make them live-only.
+
+  // Nuxt pins the major in the docs path, so these need revisiting at 5.x.
+  nuxt: {
+    routing: {
+      local: "nuxt/routing.md",
+      url: "https://nuxt.com/docs/4.x/getting-started/routing",
+    },
+    "data-fetching": {
+      local: "nuxt/data-fetching.md",
+      url: "https://nuxt.com/docs/4.x/getting-started/data-fetching",
+    },
+    "state-management": {
+      local: "nuxt/state-management.md",
+      url: "https://nuxt.com/docs/4.x/getting-started/state-management",
+    },
+    testing: {
+      local: "nuxt/testing.md",
+      url: "https://nuxt.com/docs/4.x/getting-started/testing",
+    },
+    deployment: {
+      local: "nuxt/deployment.md",
+      url: "https://nuxt.com/docs/4.x/getting-started/deployment",
+    },
+  },
+
+  // Remix has no docs site of its own any more: remix.run is a v3 beta landing
+  // page, remix.run/docs redirects off-host, and the v2 docs at v2.remix.run
+  // self-describe as legacy and point to React Router. The Remix framework is
+  // now React Router's Framework Mode, so that is where these point.
+  remix: {
+    routing: {
+      local: "remix/routing.md",
+      url: "https://reactrouter.com/start/framework/routing",
+    },
+    "data-loading": {
+      local: "remix/data-loading.md",
+      url: "https://reactrouter.com/start/framework/data-loading",
+    },
+    actions: {
+      local: "remix/actions.md",
+      url: "https://reactrouter.com/start/framework/actions",
+    },
+    testing: {
+      local: "remix/testing.md",
+      url: "https://reactrouter.com/start/framework/testing",
+    },
+    deploying: {
+      local: "remix/deploying.md",
+      url: "https://reactrouter.com/start/framework/deploying",
+    },
+  },
+
+  astro: {
+    routing: {
+      local: "astro/routing.md",
+      url: "https://docs.astro.build/en/guides/routing/",
+    },
+    components: {
+      local: "astro/components.md",
+      url: "https://docs.astro.build/en/basics/astro-components/",
+    },
+    "content-collections": {
+      local: "astro/content-collections.md",
+      url: "https://docs.astro.build/en/guides/content-collections/",
+    },
+    middleware: {
+      local: "astro/middleware.md",
+      url: "https://docs.astro.build/en/guides/middleware/",
+    },
+    deployment: {
+      local: "astro/deployment.md",
+      url: "https://docs.astro.build/en/guides/deploy/",
+    },
+  },
 };

--- a/mcp-servers/documentation/src/docs-index/testing.ts
+++ b/mcp-servers/documentation/src/docs-index/testing.ts
@@ -30,6 +30,10 @@ export const TESTING_TECHNOLOGIES = [
   // Performance & Contract testing
   "load-testing",
   "contract-testing",
+  // JVM testing
+  "junit",
+  "jacoco",
+  "rest-assured",
 ] as const;
 
 export const testingDocs: DocsRecord = {
@@ -321,6 +325,39 @@ export const testingDocs: DocsRecord = {
     "consumer-driven": {
       local: "contract-testing/consumer-driven.md",
       url: "https://martinfowler.com/articles/consumerDrivenContracts.html",
+    },
+  },
+
+  // The JUnit user guide moved host: junit.org/junit5/docs/current/user-guide/
+  // now redirects to docs.junit.org, which is used directly here.
+  junit: {
+    cheatsheet: {
+      local: "junit/quick-ref/cheatsheet.md",
+      url: "https://docs.junit.org/current/writing-tests/intro.html",
+    },
+    "testing-strategies": {
+      local: "junit/deep-docs/testing-strategies.md",
+      url: "https://docs.junit.org/current/user-guide/",
+    },
+  },
+
+  jacoco: {
+    config: {
+      local: "jacoco/quick-ref/config.md",
+      url: "https://www.jacoco.org/jacoco/trunk/doc/maven.html",
+    },
+    "ci-integration": {
+      local: "jacoco/deep-docs/ci-integration.md",
+      url: "https://www.jacoco.org/jacoco/trunk/doc/integrations.html",
+    },
+  },
+
+  // rest-assured.io hosts no documentation itself — it links out to the
+  // GitHub wiki, which is the real usage guide.
+  "rest-assured": {
+    "spring-boot-testing": {
+      local: "rest-assured/deep-docs/spring-boot-testing.md",
+      url: "https://github.com/rest-assured/rest-assured/wiki/Usage",
     },
   },
 };

--- a/mcp-servers/documentation/src/docs-index/tooling.ts
+++ b/mcp-servers/documentation/src/docs-index/tooling.ts
@@ -21,10 +21,12 @@ export const TOOLING_TECHNOLOGIES = [
   "biome",
   "eslint",
   "cpp-quality",
+  "ruff",
   // Validation
   "zod",
   "yup",
   "class-validator",
+  "pydantic",
   // Logging - Java
   "logback",
   "slf4j",
@@ -96,6 +98,48 @@ export const toolingDocs: DocsRecord = {
     plugins: {
       local: "vite/plugins.md",
       url: "https://vite.dev/plugins/",
+    },
+    optimization: {
+      local: "vite/deep-docs/optimization.md",
+      url: "https://vite.dev/guide/performance",
+    },
+  },
+
+  ruff: {
+    basics: {
+      local: "ruff/basics.md",
+      url: "https://docs.astral.sh/ruff/",
+    },
+    configuration: {
+      local: "ruff/configuration.md",
+      url: "https://docs.astral.sh/ruff/configuration/",
+    },
+    formatter: {
+      local: "ruff/formatter.md",
+      url: "https://docs.astral.sh/ruff/formatter/",
+    },
+    rules: {
+      local: "ruff/rules.md",
+      url: "https://docs.astral.sh/ruff/rules/",
+    },
+  },
+
+  pydantic: {
+    models: {
+      local: "pydantic/models.md",
+      url: "https://pydantic.dev/docs/validation/latest/concepts/models/",
+    },
+    validation: {
+      local: "pydantic/validation.md",
+      url: "https://pydantic.dev/docs/validation/latest/concepts/validators/",
+    },
+    types: {
+      local: "pydantic/types.md",
+      url: "https://pydantic.dev/docs/validation/latest/concepts/types/",
+    },
+    settings: {
+      local: "pydantic/settings.md",
+      url: "https://pydantic.dev/docs/validation/latest/concepts/pydantic_settings/",
     },
   },
 

--- a/mcp-servers/documentation/src/docs-index/types.ts
+++ b/mcp-servers/documentation/src/docs-index/types.ts
@@ -5,7 +5,17 @@
 
 export interface DocEntry {
   local: string;
-  url: string;
+  /**
+   * Canonical upstream page, used as the live fallback when the KB copy is
+   * unavailable.
+   *
+   * Optional because a few KB articles genuinely have no upstream: they
+   * document undocumented proprietary formats (ABB Freelance .dmf/.prt) or
+   * in-house workflows and cross-vendor comparisons that no vendor publishes.
+   * Pointing those at a loosely-related product page would assert an authority
+   * that does not exist, so they omit `url` and are served from the KB only.
+   */
+  url?: string;
 }
 
 export type DocsRecord = Record<string, Record<string, DocEntry>>;

--- a/mcp-servers/documentation/src/handlers/fetch-docs.ts
+++ b/mcp-servers/documentation/src/handlers/fetch-docs.ts
@@ -72,6 +72,16 @@ export const handleFetchDocs: Handler = async (args, ctx): Promise<HandlerResult
     });
   }
 
+  // KB-only topic: no upstream page exists to fall back to (proprietary
+  // formats, in-house workflows, cross-vendor comparisons). Say so plainly
+  // rather than serving an unrelated page.
+  if (!entry.url) {
+    return jsonResponse({
+      error: `Topic "${topic}" for ${technology} has no live source`,
+      hint: "This topic exists only in the knowledge base. Enable Git mode with KB_REPO_URL to read it.",
+    });
+  }
+
   // Fetch from live URL
   const rawContent = await fetchLiveDocs(entry.url);
   const { content: processedContent, truncated, originalLength } = processContent(rawContent, {

--- a/mcp-servers/documentation/src/handlers/types.ts
+++ b/mcp-servers/documentation/src/handlers/types.ts
@@ -78,7 +78,7 @@ export const CATEGORIES = [
   "infrastructure", "languages", "api", "auth", "desktop", "tooling",
   "standards", "observability", "architecture", "ai", "security", "ux",
   "rag", "retrieval", "embeddings", "vector-stores",
-  "document-processing", "rag-frameworks", "rag-ops",
+  "document-processing", "rag-frameworks", "rag-ops", "industrial",
 ] as const;
 
 export const ListDocsSchema = z.object({

--- a/mcp-servers/documentation/tests/docs-index.test.ts
+++ b/mcp-servers/documentation/tests/docs-index.test.ts
@@ -60,12 +60,15 @@ describe('docs-index', () => {
       });
     });
 
-    it('should give every topic a non-empty local and url', () => {
+    it('should give every topic a local, and a well-formed url when it has one', () => {
       Object.entries(docsIndex).forEach(([tech, topics]) => {
         Object.entries(topics).forEach(([topic, entry]) => {
           expect(entry.local, `${tech}/${topic} local`).toBeTruthy();
-          expect(entry.url, `${tech}/${topic} url`).toMatch(/^https?:\/\//);
           expect(entry.local, `${tech}/${topic} local`).toMatch(/\.md$/);
+          // `url` is optional: KB-only topics have no upstream page.
+          if (entry.url !== undefined) {
+            expect(entry.url, `${tech}/${topic} url`).toMatch(/^https?:\/\//);
+          }
         });
       });
     });

--- a/mcp-servers/documentation/tests/fetch-docs-live.test.ts
+++ b/mcp-servers/documentation/tests/fetch-docs-live.test.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+import { describe, it, expect } from "vitest";
+import { handleFetchDocs } from "../src/handlers/fetch-docs.js";
+import type { HandlerContext } from "../src/handlers/types.js";
+import { docsIndex } from "../src/docs-index.js";
+
+// Live-only context: no KB, so the handler goes straight to the url fallback.
+const liveCtx: HandlerContext = {
+  kbMode: "live_only",
+  kbCache: null,
+  kbFetcher: null,
+  versionResolver: null,
+  config: { cachePath: "", ttl: 0 },
+};
+
+const parse = (result: { content: Array<{ text: string }> }) => JSON.parse(result.content[0].text);
+
+// A few KB articles document proprietary formats or in-house workflows that
+// have no upstream page, so their entries carry no `url`. Live mode must say
+// so rather than dereference undefined or serve an unrelated page.
+describe("fetch_docs live fallback for KB-only topics", () => {
+  it("reports no live source when the entry has no url", async () => {
+    const result = await handleFetchDocs(
+      { technology: "abb-freelance", topic: "dmf-format", source: "live" },
+      liveCtx
+    );
+
+    const body = parse(result);
+    expect(body.error).toMatch(/no live source/i);
+    expect(body.hint).toMatch(/knowledge base/i);
+    expect(body.content).toBeUndefined();
+  });
+
+  it("keeps the url fallback working for topics that do have one", async () => {
+    // Only assert the entry shape here — actually fetching would hit the network.
+    expect(docsIndex["abb-freelance"].overview.url).toMatch(/^https:\/\//);
+    expect(docsIndex["abb-freelance"]["dmf-format"].url).toBeUndefined();
+  });
+
+  it("only omits url where a topic genuinely has no upstream", () => {
+    const urlless = Object.entries(docsIndex).flatMap(([tech, topics]) =>
+      Object.entries(topics)
+        .filter(([, entry]) => entry.url === undefined)
+        .map(([topic]) => `${tech}/${topic}`)
+    );
+
+    // Pin the exhaustive list: adding a url-less entry should be a deliberate
+    // act, not something that slips in from a forgotten field.
+    expect(urlless.sort()).toEqual([
+      "abb-freelance/dmf-format",
+      "abb-freelance/prt-format",
+      "bulk-engineering/python-generation",
+      "dcs-platforms/overview",
+    ]);
+  });
+});


### PR DESCRIPTION
Second half of #116. **Stacked on #118** — review that first; this PR's diff is only the second commit.

Where #118 was mechanical, these orphans needed research: each entry's `url` was individually fetched and confirmed to load and match its topic.

## Three problems, one root cause

Reachability is decided by `SUPPORTED_TECHNOLOGIES`, not by `local` — both tools declare `technology: z.enum([...SUPPORTED_TECHNOLOGIES])`, so anything outside that list is rejected at parse time.

1. **64 KB files across 26 technologies were hard-blocked.** `anthropic`, `mcp-sdk`, `pydantic`, `ruff`, `streamlit`, `junit`, `jacoco`, `radix-ui`, the SQL dialects, the industrial/DCS set and others were absent from the list entirely, so their content was unreachable in every mode.
2. **10 ghost technologies.** Listed as supported with *zero* entries. `python` and `svelte` worked anyway through the key-derived fallback, but `solid`, `nuxt`, `remix`, `astro`, `fastify`, `hono`, `django`, `flask` had neither entries nor KB content — git mode missed, live mode found no entry, so **every request for them errored** while the server advertised them. They are now live-only, the same shape the index already uses for its 43 other KB-less technologies.
3. **`docsIndex` was typed with an inline duplicate of `DocEntry`** (`{ local: string; url: string }`) instead of the real type. Now uses `DocsRecord`.

## `DocEntry.url` becomes optional

Four KB articles have **no upstream page at all**: the ABB Freelance `.dmf`/`.prt` record layouts are undocumented proprietary internals (the articles are reverse-engineered field knowledge), `python-generation` is an in-house workflow, and `dcs-platforms/overview` is a four-way vendor comparison no vendor publishes.

Pointing those at a loosely-related product page would assert an authority that does not exist, so they omit `url`, and live mode returns an explicit *"no live source"* error rather than serving an unrelated page. One call site was affected (`fetch-docs.ts:76`). The test pins the exhaustive list of url-less entries, so adding another is a deliberate act.

## Verifying the urls surfaced four moved doc sites

- **Anthropic** — `docs.anthropic.com` *and* `docs.claude.com` both 301 to `platform.claude.com`.
- **Pydantic** — `docs.pydantic.dev/latest/...` 301s to `pydantic.dev/docs/validation/latest/...`.
- **JUnit** — `junit.org/junit5/docs/current/user-guide/` 301s to `docs.junit.org`.
- **Remix** — has no docs site any more. `remix.run` is a v3 beta landing page, `remix.run/docs` redirects off-host, and the v2 docs self-describe as legacy pointing at React Router. The Remix framework *is* React Router's Framework Mode now, so `remix/*` points at `reactrouter.com`.

Judgement calls worth a look, all commented in-place: `migrations/basics` is tool-agnostic (Flyway, Liquibase, Alembic, Prisma and Rails get equal billing) so Flyway is a deliberately weak anchor; `sql-fundamentals` is nominally vendor-neutral but its examples are PostgreSQL-flavoured, so the PostgreSQL manual is the honest fit; ISA/IEC standards are paid, so their `url` is the official landing page — not one of the unlicensed PDF copies.

## Verification

| | before | after |
|---|---|---|
| KB orphans | 392 (70 after #118) | **1** |
| ghost technologies | 10 | **0** |
| index entries with a `local` | 1490 (after #118) | **1599** |
| dangling `local` | 148 | 188 |

The dangling delta is exactly accounted for: **39** are the 8 live-only ghosts (inert by design — the `url` is the intended source) and **1** is `bulk-engineering/namur-ne150.md`. Every technology with real KB content has **zero** dangling paths.

Green: `tsc --noEmit`, `npm run build`, 75 tests passing (72 + 3), plus `validate-catalog`, `validate-frontmatter`, `check-type-sync` and the MCP description audit.

## Cross-repo dependency

The last orphan and the last dangling path are the same file. claude-dev-suite/knowledge_base#9 renames `namur-ne148.md` → `namur-ne150.md` (the article documents NE 150; NE 148 is an unrelated recommendation about modular plants, and both of the file's cited sources 404). This PR already points at the new name, so **that PR should merge first**. Until it does, that one `local` dangles and degrades to the live NAMUR page — not an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)