### PR TITLE
fix(documentation): make DocEntry.local optional so live-only topics skip the KB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,6 +280,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **20 documentation topics paid for a KB lookup that could never succeed.**
+  Their index entries named a `local` file the knowledge base does not have — in
+  every case an article the KB simply never wrote, with the real content already
+  reachable under another topic key, so there was nothing to repoint them to. Git
+  mode sparse-checked-out the directory anyway, failed, logged
+  `[KB] Git fetch failed, falling back to live:` and served the upstream `url` —
+  the right answer, at the cost of a wasted checkout and an error line on every
+  request. `DocEntry.local` is now optional and says the same thing by absence:
+  `fetch_docs` skips git mode for a known topic that declares none, and an
+  unindexed topic still tries the key-derived path. Verified against the live KB
+  with `scripts/audit-kb-index.mjs`: real mismatches 0, orphans 0, unreachable 0.
+  One behaviour change: `list_topics` in git mode no longer enumerates a KB
+  directory for `server-performance` and `server-hardening`, whose fake `local`
+  pointed into `linux/` and made them answer with the articles `linux-server`
+  owns. (#117)
 - **An install deleted the user's own MCP servers from `.mcp.json`.** The Claude
   Code adapter was the only one that wrote its MCP config without merging, while
   `uninstall.ts` lists that same file under `SHARED_CONFIGS` and un-merges it

--- a/mcp-servers/documentation/src/docs-index/databases.ts
+++ b/mcp-servers/documentation/src/docs-index/databases.ts
@@ -49,15 +49,12 @@ export const databaseDocs: DocsRecord = {
 
   mongodb: {
     queries: {
-      local: "mongodb/queries.md",
       url: "https://www.mongodb.com/docs/manual/crud/",
     },
     indexes: {
-      local: "mongodb/indexes.md",
       url: "https://www.mongodb.com/docs/manual/indexes/",
     },
     aggregation: {
-      local: "mongodb/aggregation.md",
       url: "https://www.mongodb.com/docs/manual/aggregation/",
     },
     production: {
@@ -68,11 +65,9 @@ export const databaseDocs: DocsRecord = {
 
   mysql: {
     queries: {
-      local: "mysql/queries.md",
       url: "https://dev.mysql.com/doc/refman/8.0/en/sql-statements.html",
     },
     indexes: {
-      local: "mysql/indexes.md",
       url: "https://dev.mysql.com/doc/refman/8.0/en/optimization-indexes.html",
     },
     production: {
@@ -83,11 +78,9 @@ export const databaseDocs: DocsRecord = {
 
   redis: {
     commands: {
-      local: "redis/commands.md",
       url: "https://redis.io/commands/",
     },
     patterns: {
-      local: "redis/patterns.md",
       url: "https://redis.io/docs/manual/patterns/",
     },
     production: {

--- a/mcp-servers/documentation/src/docs-index/frontend.ts
+++ b/mcp-servers/documentation/src/docs-index/frontend.ts
@@ -107,7 +107,6 @@ export const frontendDocs: DocsRecord = {
       url: "https://tailwindcss.com/docs/configuration",
     },
     spacing: {
-      local: "tailwind/spacing.md",
       url: "https://tailwindcss.com/docs/customizing-spacing",
     },
   },
@@ -175,7 +174,6 @@ export const frontendDocs: DocsRecord = {
       url: "https://pinia.vuejs.org/core-concepts/",
     },
     composables: {
-      local: "pinia/composables.md",
       url: "https://pinia.vuejs.org/cookbook/composing-stores.html",
     },
   },

--- a/mcp-servers/documentation/src/docs-index/industrial.ts
+++ b/mcp-servers/documentation/src/docs-index/industrial.ts
@@ -111,8 +111,8 @@ export const industrialDocs: DocsRecord = {
       local: "bulk-engineering/namur-ne148.md",
       url: "https://www.namur.net/en/recommendations/namur-recommendations/detail/ne-148.html",
     },
+    // NE 150 has no KB article, so no `local`: it is served from NAMUR.
     "namur-ne150": {
-      local: "bulk-engineering/namur-ne150.md",
       url: "https://www.namur.net/en/publications/news-archive/ne-150-is-newly-published.html",
     },
     // No url: in-house generation workflow (template conventions, chunking

--- a/mcp-servers/documentation/src/docs-index/infrastructure.ts
+++ b/mcp-servers/documentation/src/docs-index/infrastructure.ts
@@ -100,7 +100,6 @@ export const infrastructureDocs: DocsRecord = {
       url: "https://docs.github.com/en/actions/using-workflows",
     },
     actions: {
-      local: "github-actions/actions.md",
       url: "https://docs.github.com/en/actions/creating-actions",
     },
     "ci-cd-patterns": {
@@ -332,16 +331,20 @@ export const infrastructureDocs: DocsRecord = {
     },
   },
 
+  // Both of these are single-topic keys with no KB article of their own. They
+  // used to name a file under `linux/`, which never existed but did give
+  // `list_topics` a KB directory to enumerate — it answered with the whole of
+  // `linux/`, i.e. the articles `linux-server` above already owns. Dropping
+  // the fake `local` also drops that listing, which was misattributing files
+  // rather than describing these topics.
   "server-performance": {
     "linux-performance-tuning": {
-      local: "linux/performance-tuning.md",
       url: "https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt",
     },
   },
 
   "server-hardening": {
     "cis-benchmark": {
-      local: "linux/server-hardening.md",
       url: "https://www.cisecurity.org/cis-benchmarks/",
     },
   },

--- a/mcp-servers/documentation/src/docs-index/meta-frameworks.ts
+++ b/mcp-servers/documentation/src/docs-index/meta-frameworks.ts
@@ -25,7 +25,6 @@ export const metaFrameworkDocs: DocsRecord = {
       url: "https://nextjs.org/docs/app/building-your-application/caching",
     },
     "server-components": {
-      local: "nextjs/server-components.md",
       url: "https://nextjs.org/docs/app/building-your-application/rendering/server-components",
     },
     "data-fetching": {

--- a/mcp-servers/documentation/src/docs-index/tooling.ts
+++ b/mcp-servers/documentation/src/docs-index/tooling.ts
@@ -80,7 +80,6 @@ export const toolingDocs: DocsRecord = {
 
   vite: {
     basics: {
-      local: "vite/basics.md",
       url: "https://vite.dev/guide/",
     },
     config: {
@@ -88,15 +87,12 @@ export const toolingDocs: DocsRecord = {
       url: "https://vite.dev/config/",
     },
     "env-variables": {
-      local: "vite/env-variables.md",
       url: "https://vite.dev/guide/env-and-mode",
     },
     build: {
-      local: "vite/build.md",
       url: "https://vite.dev/guide/build",
     },
     plugins: {
-      local: "vite/plugins.md",
       url: "https://vite.dev/plugins/",
     },
     optimization: {
@@ -248,7 +244,6 @@ export const toolingDocs: DocsRecord = {
   // Validation
   zod: {
     basics: {
-      local: "zod/basics.md",
       url: "https://zod.dev/?id=basic-usage",
     },
     schemas: {
@@ -260,7 +255,6 @@ export const toolingDocs: DocsRecord = {
       url: "https://zod.dev/?id=parse",
     },
     transforms: {
-      local: "zod/transforms.md",
       url: "https://zod.dev/?id=transform",
     },
   },

--- a/mcp-servers/documentation/src/docs-index/types.ts
+++ b/mcp-servers/documentation/src/docs-index/types.ts
@@ -4,7 +4,20 @@
  */
 
 export interface DocEntry {
-  local: string;
+  /**
+   * Where the article lives inside the knowledge base, relative to
+   * `knowledge/` (e.g. "bitcoin/protocol/consensus/overview.md"). Git mode
+   * derives its sparse-checkout coordinates from this rather than from the
+   * record keys, which frequently differ from the on-disk layout.
+   *
+   * Optional because a topic can be genuinely live-only: the KB never wrote an
+   * article for it and the upstream `url` is the whole answer. Naming a file
+   * that does not exist used to be the way those were spelled, which cost a
+   * failed sparse checkout and an error log on every request before the handler
+   * fell through to `url`. Omitting `local` says the same thing and skips the
+   * checkout. An entry must carry at least one of `local` and `url`.
+   */
+  local?: string;
   /**
    * Canonical upstream page, used as the live fallback when the KB copy is
    * unavailable.

--- a/mcp-servers/documentation/src/handlers/fetch-docs.ts
+++ b/mcp-servers/documentation/src/handlers/fetch-docs.ts
@@ -14,13 +14,20 @@ export const handleFetchDocs: Handler = async (args, ctx): Promise<HandlerResult
 
   const entry = docsIndex[technology]?.[topic];
 
+  // A known topic that declares no `local` has no KB article: the index says so
+  // explicitly, so skip git mode rather than sparse-checking out a directory to
+  // rediscover it. An unknown topic still tries the key-derived path — that is
+  // how a KB file the index has not caught up with is reachable.
+  const hasKbArticle = !entry || entry.local !== undefined;
+
   // On-demand KB mode with versioning support
-  if (ctx.kbMode === "git" && ctx.kbFetcher && ctx.versionResolver) {
+  if (ctx.kbMode === "git" && ctx.kbFetcher && ctx.versionResolver && hasKbArticle) {
     try {
       // Resolve the real KB location from the index `local` path (the record
       // keys often differ from the on-disk layout, e.g. technology
-      // "bitcoin-consensus" → "bitcoin/protocol/consensus/overview.md"). Falls
-      // back to the key-derived path when `local` is missing.
+      // "bitcoin-consensus" → "bitcoin/protocol/consensus/overview.md"). Only
+      // an unindexed topic gets here without one, and falls back to the
+      // key-derived path.
       const { dir, topicStem } = resolveKbCoords(entry?.local, technology, topic);
 
       // Fetch/cache the KB directory first

--- a/mcp-servers/documentation/src/handlers/list-topics.ts
+++ b/mcp-servers/documentation/src/handlers/list-topics.ts
@@ -12,9 +12,11 @@ export const handleListTopics: Handler = async (args, ctx): Promise<HandlerResul
 
   // Resolve the real KB directory from any topic's `local` path (they share the
   // same first segment) so technologies whose key differs from the on-disk
-  // directory still list correctly.
-  const firstTopic = Object.keys(docsIndex[technology] || {})[0];
-  const kbDir = resolveKbDir(docsIndex[technology]?.[firstTopic]?.local, technology);
+  // directory still list correctly. `local` is optional — a live-only topic
+  // omits it — so scan for the first topic that has one instead of trusting
+  // whichever happens to be first.
+  const entries = Object.values(docsIndex[technology] || {});
+  const kbDir = resolveKbDir(entries.find((e) => e?.local)?.local, technology);
 
   // Git mode - fetch from cached KB
   if (ctx.kbMode === "git" && ctx.kbFetcher) {

--- a/mcp-servers/documentation/tests/docs-index.test.ts
+++ b/mcp-servers/documentation/tests/docs-index.test.ts
@@ -60,17 +60,59 @@ describe('docs-index', () => {
       });
     });
 
-    it('should give every topic a local, and a well-formed url when it has one', () => {
+    // Both fields are optional, for opposite reasons: a KB-only topic has no
+    // upstream page, and a live-only topic has no KB article. Neither may be
+    // absent at the same time — that entry names nothing at all.
+    it('gives every topic a local or a url, each well-formed when present', () => {
       Object.entries(docsIndex).forEach(([tech, topics]) => {
         Object.entries(topics).forEach(([topic, entry]) => {
-          expect(entry.local, `${tech}/${topic} local`).toBeTruthy();
-          expect(entry.local, `${tech}/${topic} local`).toMatch(/\.md$/);
-          // `url` is optional: KB-only topics have no upstream page.
+          expect(
+            entry.local !== undefined || entry.url !== undefined,
+            `${tech}/${topic} has neither local nor url`
+          ).toBe(true);
+          if (entry.local !== undefined) {
+            expect(entry.local, `${tech}/${topic} local`).toBeTruthy();
+            expect(entry.local, `${tech}/${topic} local`).toMatch(/\.md$/);
+          }
           if (entry.url !== undefined) {
             expect(entry.url, `${tech}/${topic} url`).toMatch(/^https?:\/\//);
           }
         });
       });
+    });
+
+    // A topic with no `local` is a deliberate statement that the KB never wrote
+    // the article — it makes `fetch_docs` skip git mode entirely. Pin the list
+    // so one cannot appear by someone forgetting the field on a real article.
+    it('only omits local where the KB genuinely has no article', () => {
+      const localless = Object.entries(docsIndex).flatMap(([tech, topics]) =>
+        Object.entries(topics)
+          .filter(([, entry]) => entry.local === undefined)
+          .map(([topic]) => `${tech}/${topic}`)
+      );
+
+      expect(localless.sort()).toEqual([
+        'bulk-engineering/namur-ne150',
+        'github-actions/actions',
+        'mongodb/aggregation',
+        'mongodb/indexes',
+        'mongodb/queries',
+        'mysql/indexes',
+        'mysql/queries',
+        'nextjs/server-components',
+        'pinia/composables',
+        'redis/commands',
+        'redis/patterns',
+        'server-hardening/cis-benchmark',
+        'server-performance/linux-performance-tuning',
+        'tailwindcss/spacing',
+        'vite/basics',
+        'vite/build',
+        'vite/env-variables',
+        'vite/plugins',
+        'zod/basics',
+        'zod/transforms',
+      ]);
     });
   });
 
@@ -90,7 +132,10 @@ describe('docs-index', () => {
 
       withDeepDives.forEach(([tech, topics]) => {
         const overview = topics.overview;
-        const dir = overview.local.slice(0, overview.local.lastIndexOf('/'));
+        // `e()`-generated records always carry a local; that is the point of
+        // the helper, and the assertion below would be vacuous without one.
+        expect(overview.local, `${tech}/overview local`).toBeDefined();
+        const dir = overview.local!.slice(0, overview.local!.lastIndexOf('/'));
 
         Object.entries(topics).forEach(([topic, entry]) => {
           if (topic === 'overview') return;

--- a/mcp-servers/documentation/tests/git-mode-skip.test.ts
+++ b/mcp-servers/documentation/tests/git-mode-skip.test.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+/**
+ * A topic whose index entry declares no `local` has no KB article. Git mode
+ * must not sparse-check-out a directory to rediscover that: the fetch throws,
+ * the handler falls through to the live url, and the only trace is a wasted
+ * checkout and an error log on every single request.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { handleFetchDocs } from "../src/handlers/fetch-docs.js";
+import { handleListTopics } from "../src/handlers/list-topics.js";
+import type { HandlerContext } from "../src/handlers/types.js";
+import { docsIndex } from "../src/docs-index.js";
+
+/** Git-mode context whose KB calls are recorded rather than performed. */
+function gitCtx() {
+  const fetch = vi.fn(async () => ["placeholder.md"]);
+  const fetchVersioned = vi.fn(async () => ({
+    content: "# from the KB",
+    version: "latest",
+    is_latest: true,
+    latest_version: "latest",
+    supported_versions: [],
+    delta_applied: false,
+    upgrade_available: false,
+  }));
+  const ctx = {
+    kbMode: "git",
+    kbCache: null,
+    kbFetcher: { fetch },
+    versionResolver: { fetchVersioned, listVersions: vi.fn(async () => null) },
+    config: { cachePath: "", ttl: 0 },
+  } as unknown as HandlerContext;
+  return { ctx, fetch, fetchVersioned };
+}
+
+const parse = (result: { content: Array<{ text: string }> }) => JSON.parse(result.content[0].text);
+
+describe("fetch_docs git mode", () => {
+  it("skips the KB entirely for a topic that declares no local", async () => {
+    expect(docsIndex["vite"]["basics"].local).toBeUndefined();
+    expect(docsIndex["vite"]["basics"].url).toMatch(/^https:\/\//);
+
+    const { ctx, fetch, fetchVersioned } = gitCtx();
+    const liveFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("# vite guide", { status: 200 }));
+
+    try {
+      const body = parse(await handleFetchDocs({ technology: "vite", topic: "basics" }, ctx));
+      expect(body.source).toBe("live");
+    } finally {
+      liveFetch.mockRestore();
+    }
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(fetchVersioned).not.toHaveBeenCalled();
+  });
+
+  it("still uses the KB for a topic that has one", async () => {
+    expect(docsIndex["vite"]["config"].local).toBe("vite/quick-ref/config.md");
+
+    const { ctx, fetch, fetchVersioned } = gitCtx();
+    const body = parse(await handleFetchDocs({ technology: "vite", topic: "config" }, ctx));
+
+    expect(body.source).toBe("git_cache");
+    expect(fetch).toHaveBeenCalledWith("vite", undefined);
+    expect(fetchVersioned).toHaveBeenCalledWith(
+      expect.objectContaining({ technology: "vite", topic: "quick-ref/config" })
+    );
+  });
+
+  it("still tries the key-derived path for a topic the index does not list", async () => {
+    expect(docsIndex["vite"]["not-indexed-yet"]).toBeUndefined();
+
+    const { ctx, fetch } = gitCtx();
+    await handleFetchDocs({ technology: "vite", topic: "not-indexed-yet" }, ctx);
+
+    expect(fetch).toHaveBeenCalledWith("vite", undefined);
+  });
+});
+
+describe("list_topics KB directory resolution", () => {
+  it("takes the directory from the first topic that has a local, not the first topic", async () => {
+    // `vite/basics` comes first in the record and is now local-less; the KB
+    // directory still has to come out as `vite`, from a later entry.
+    const { ctx, fetch } = gitCtx();
+    await handleListTopics({ technology: "vite" }, ctx);
+
+    expect(fetch).toHaveBeenCalledWith("vite");
+  });
+
+  it("keeps resolving a technology whose key differs from its KB directory", async () => {
+    // `tailwindcss` is indexed under the KB directory `tailwind`.
+    const { ctx, fetch } = gitCtx();
+    await handleListTopics({ technology: "tailwindcss" }, ctx);
+
+    expect(fetch).toHaveBeenCalledWith("tailwind");
+  });
+});


### PR DESCRIPTION
Closes #117 — implements the option the issue's last comment left open ("make `local` optional"), after re-verifying the count against the live KB.

## What was wrong

20 index entries name a `local` file the knowledge base does not have. `scripts/audit-kb-index.mjs` before this change:

```
REAL MISMATCH         : 20
ORPHANS (non-version) : 0
GHOST TECHNOLOGIES    : 0
UNREACHABLE (no url)  : 0
```

Nothing failed for the user: `fetch-docs.ts` catches the git-mode throw and serves the upstream `url`. The cost was one wasted sparse checkout plus a `[KB] Git fetch failed, falling back to live:` line **per request**.

In every one of the 20, the KB files that *do* exist in that directory are already indexed under other topic keys, so repointing was not available — the KB never wrote these articles.

## What changed

- `DocEntry.local` is now optional, and its absence is the statement "the KB has no article for this topic".
- `fetch-docs.ts` skips git mode for a **known** topic that declares no `local`. An **unindexed** topic still tries the key-derived path — that is how a KB file the index has not caught up with stays reachable.
- `list-topics.ts` derives its KB directory from the first topic that *has* a `local`, instead of whichever topic happens to be first (`vite/basics` is now local-less and first).
- The 20 fake `local` fields are gone; every one of those entries keeps its `url`.

After:

```
REAL MISMATCH         : 0
ORPHANS (non-version) : 0
GHOST TECHNOLOGIES    : 0
UNREACHABLE (no url)  : 0
```

## One deliberate behaviour change

`server-performance` and `server-hardening` are single-topic keys whose fake `local` pointed into `linux/`. That path never existed, but it did hand `list_topics` a real KB directory to enumerate — so in git mode they answered with the whole of `linux/`, i.e. the three articles `linux-server` owns. Removing the `local` removes that listing. It was misattributing files rather than describing those topics, so it is dropped rather than preserved. Both topics still resolve normally through `fetch_docs` → `url`.

## Tests

- `docs-index.test.ts`: the "every topic has a local" invariant becomes "every topic has a `local` **or** a `url`, each well-formed when present", plus a new pinned list of the 20 local-less topics so one cannot appear by someone forgetting the field on a real article.
- `git-mode-skip.test.ts` (new): a local-less topic never touches `kbFetcher`/`versionResolver` and comes back `source: "live"`; a topic with a `local` still fetches `vite` + `quick-ref/config`; an unindexed topic still tries the key-derived path; `list_topics` still resolves `tailwindcss` → `tailwind`.

`npx vitest run documentation/tests/` → 8 files, 93 passed. `tsc --noEmit` + bundle clean. `audit-mcp-descriptions`, `validate-catalog`, `check-type-sync`, `check-docs-sync` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
