### PR TITLE
fix(codeql): close the five open path-injection and sanitization alerts

### DIFF
--- a/.github/codeql/custom-queries/javascript/path-sanitizers.model.yml
+++ b/.github/codeql/custom-queries/javascript/path-sanitizers.model.yml
@@ -80,5 +80,19 @@ extensions:
       # caller checks for null before using it.
       - ["file:configurator/dashboard/server/src/services/installation/uninstall.ts", "Member[resolveInsideProject].ReturnValue", "path-injection"]
 
+      # assertValidComponentId(id, label) — throws unless the id matches
+      # VALID_COMPONENT_NAME, `^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$`. No separator,
+      # no dot, so the result is a single path segment by construction; this is
+      # the guard added for the traversals fixed in dd0ec86.
+      #
+      # It used to return void, which no data extension can attach to —
+      # `barrierModel` marks a node, and an assertion produces none, while
+      # marking `Argument[0]` would not help because the flow continues from the
+      # variable rather than the call. It returns the validated id now, and the
+      # callers that build a path assign it back, so the value at the sink is
+      # the one this checked.
+      - ["file:configurator/dashboard/server/src/services/installation/security-helpers.ts", "Member[assertValidComponentId].ReturnValue", "path-injection"]
+      - ["file:configurator/dashboard/server/src/services/installation/index.ts", "Member[assertValidComponentId].ReturnValue", "path-injection"]
+
       # resolveProjectPath(raw) — see the threat-model note above.
       - ["file:configurator/dashboard/server/src/utils/utilities.ts", "Member[resolveProjectPath].ReturnValue", "path-injection"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Security
 
+- **A generated file could be written outside the project through a symlinked
+  directory.** `codegen.service.ts` confined its writes with
+  `resolvedFilePath.startsWith(resolvedProject + path.sep)`, a comparison
+  between paths neither of which had been canonicalised — an intermediate
+  directory that is a symlink satisfies the prefix and redirects the write
+  anyway. It now goes through `validatePathWithinBase`, the same guard the
+  installation pipeline uses, which realpaths the deepest existing ancestor
+  before deciding and refuses a path it cannot canonicalise. The write uses the
+  value the guard returned, not the one it was handed.
 - **Two path traversals reaching destructive filesystem calls.** Custom
   agent/skill ids (`agentId`, `skillId`) were validated on the *create* path and
   nowhere else, so `DELETE /api/custom-skills/..%2F..%2Fsrc` reached a recursive
@@ -280,6 +289,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **The agent reference generator did not escape backslashes.** `focus()`
+  escaped `|` for the markdown table but left existing backslashes alone, so a
+  description containing `\|` became `\\|` — a literal backslash followed by a
+  column break. No current agent description reaches it, so the generated README
+  section is unchanged; the escaping is now correct for the one that will.
+  (CodeQL `js/incomplete-sanitization`)
+- **`assertValidComponentId` now returns the id it validated.** It returned
+  void, and `js/path-injection` follows the variable rather than the call, so
+  the guard was invisible to CodeQL and every `path.join` fed by an agent id or
+  server name in `management.service.ts` read as an unchecked write. The four
+  call sites there assign the result back, and the validator is named as a
+  barrier alongside the others. The check itself is unchanged; the value at the
+  sink is now demonstrably the checked one.
 - **20 documentation topics paid for a KB lookup that could never succeed.**
   Their index entries named a `local` file the knowledge base does not have — in
   every case an article the KB simply never wrote, with the real content already

--- a/configurator/dashboard/server/src/services/codegen.service.ts
+++ b/configurator/dashboard/server/src/services/codegen.service.ts
@@ -16,6 +16,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { resolveProjectPath, PathValidationError } from '../utils/utilities.js';
+import { validatePathWithinBase } from './installation/security-helpers.js';
 import { getLogger } from '../utils/logger.js';
 import type {
   CodeGenTechnology,
@@ -538,17 +539,32 @@ export class CodeGenService {
           ? file.path
           : path.join(baseOutputDir, ...trimmed);
 
-        const rootWithSep = resolvedProject.endsWith(path.sep) ? resolvedProject : resolvedProject + path.sep;
-        if (resolvedFilePath.includes('..') || (!resolvedFilePath.startsWith(rootWithSep) && resolvedFilePath !== resolvedProject)) {
-          logger.warn('Skipping file outside project boundary', { data: { filePath: resolvedFilePath } });
+        // The shared guard rather than a hand-rolled prefix comparison. Both
+        // reject lexical traversal and confine the write to the project, but
+        // `startsWith(root + sep)` compares un-canonicalised paths: a symlinked
+        // intermediate directory satisfies the prefix and still redirects the
+        // write outside. `validatePathWithinBase` realpaths the deepest existing
+        // ancestor before deciding, and refuses a path it cannot canonicalise.
+        // It is also the function `barrierModel` names, so the sink below is
+        // recognisably guarded instead of reading as an unchecked write.
+        let safeFilePath: string;
+        try {
+          // allowBase: false — the project root is a directory; a generated file
+          // resolving to it exactly is nothing this should try to write.
+          safeFilePath = validatePathWithinBase(resolvedFilePath, resolvedProject, false);
+        } catch (err) {
+          logger.warn('Skipping file outside project boundary', {
+            error: err,
+            data: { filePath: resolvedFilePath },
+          });
           skipped.push(file.path);
           continue;
         }
 
-        fs.mkdirSync(path.dirname(resolvedFilePath), { recursive: true });
-        fs.writeFileSync(resolvedFilePath, file.content, 'utf-8');
-        written.push(resolvedFilePath);
-        logger.debug('Written file', { data: { path: resolvedFilePath } });
+        fs.mkdirSync(path.dirname(safeFilePath), { recursive: true });
+        fs.writeFileSync(safeFilePath, file.content, 'utf-8');
+        written.push(safeFilePath);
+        logger.debug('Written file', { data: { path: safeFilePath } });
       } catch (err) {
         logger.error('Failed to write file', { error: err, data: { filePath: file.path } });
         skipped.push(file.path);

--- a/configurator/dashboard/server/src/services/installation/security-helpers.ts
+++ b/configurator/dashboard/server/src/services/installation/security-helpers.ts
@@ -124,14 +124,24 @@ export const VALID_COMPONENT_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
  * `renameSync` of an arbitrary directory. Every entry point now goes through
  * here.
  *
+ * Returns the id it validated. Callers that build a path from it should use the
+ * returned value rather than the argument they passed in: `js/path-injection`
+ * follows the variable, not the call, so a void assertion is invisible to it —
+ * a return value is the only thing `barrierModel` in
+ * `.github/codeql/custom-queries/javascript/path-sanitizers.model.yml` can
+ * attach to. The claim it encodes is a fact about `VALID_COMPONENT_NAME`: no
+ * `/`, no `\`, no `.`, so the result is a single path segment by construction.
+ *
  * @throws Error when the id is not a single safe segment
+ * @returns the validated id, unchanged
  */
-export function assertValidComponentId(id: string, label = 'ID'): void {
+export function assertValidComponentId(id: string, label = 'ID'): string {
   if (typeof id !== 'string' || !VALID_COMPONENT_NAME.test(id)) {
     throw new Error(
       `Invalid ${label}: must start with a letter or digit and contain only letters, digits, hyphens and underscores (max 64 characters)`
     );
   }
+  return id;
 }
 
 /**

--- a/configurator/dashboard/server/src/services/management.service.ts
+++ b/configurator/dashboard/server/src/services/management.service.ts
@@ -132,7 +132,7 @@ export class ManagementService {
     if (projectPath.includes('..')) throw new PathValidationError('Path traversal not allowed');
     projectPath = resolveProjectPath(projectPath);
     if (!path.isAbsolute(projectPath)) throw new PathValidationError('Path must be rooted');
-    assertValidComponentId(agentId, 'agent ID');
+    agentId = assertValidComponentId(agentId, 'agent ID');
     const devSuiteDir = getDevSuiteDir();
     const agentFile = this.findAgentFile(path.join(devSuiteDir, 'agents'), agentId + '.md');
 
@@ -234,7 +234,7 @@ export class ManagementService {
     if (projectPath.includes('..')) throw new PathValidationError('Path traversal not allowed');
     projectPath = resolveProjectPath(projectPath);
     if (!path.isAbsolute(projectPath)) throw new PathValidationError('Path must be rooted');
-    assertValidComponentId(agentId, 'agent ID');
+    agentId = assertValidComponentId(agentId, 'agent ID');
     const paths = targetPaths(projectPath);
     const agentPath = paths.agentFile(agentId);
 
@@ -291,7 +291,7 @@ export class ManagementService {
     if (projectPath.includes('..')) throw new PathValidationError('Path traversal not allowed');
     projectPath = resolveProjectPath(projectPath);
     if (!path.isAbsolute(projectPath)) throw new PathValidationError('Path must be rooted');
-    assertValidComponentId(serverName, 'server name');
+    serverName = assertValidComponentId(serverName, 'server name');
 
     const devSuiteDir = getDevSuiteDir();
     const serverSource = path.join(devSuiteDir, 'mcp-servers', serverName);
@@ -332,7 +332,7 @@ export class ManagementService {
     if (projectPath.includes('..')) throw new PathValidationError('Path traversal not allowed');
     projectPath = resolveProjectPath(projectPath);
     if (!path.isAbsolute(projectPath)) throw new PathValidationError('Path must be rooted');
-    assertValidComponentId(serverName, 'server name');
+    serverName = assertValidComponentId(serverName, 'server name');
 
     const paths = targetPaths(projectPath);
     const serverDir = paths.mcpServerDir(serverName);

--- a/configurator/dashboard/server/tests/security-hardening.test.ts
+++ b/configurator/dashboard/server/tests/security-hardening.test.ts
@@ -802,17 +802,26 @@ describe('R2 — SSRF numeric IP encoding normalisation', () => {
   });
 });
 
-// ─── R3: startsWith+path.sep — codegen.service.ts boundary check ─────────────
+// ─── R3: codegen.service.ts confines generated writes to the project ─────────
 
-describe('R3 — codegen.service.ts path boundary uses path.sep', () => {
-  it('codegen.service.ts source uses rootWithSep pattern', () => {
+describe('R3 — codegen.service.ts path boundary', () => {
+  it('routes the write through validatePathWithinBase, not a prefix comparison', () => {
     const src = fs.readFileSync(
       path.join(import.meta.dirname ?? __dirname, '../src/services/codegen.service.ts'),
       'utf-8',
     );
-    // The fix adds a rootWithSep variable; verify it is present
-    expect(src).toContain('rootWithSep');
-    expect(src).toContain('path.sep');
+    // This used to assert a `rootWithSep` variable, i.e. the original fix's
+    // `resolvedFilePath.startsWith(resolvedProject + path.sep)`. That compares
+    // un-canonicalised paths: a symlinked intermediate directory satisfies the
+    // prefix and redirects the write outside the project anyway. The shared
+    // guard realpaths the deepest existing ancestor before deciding, and is the
+    // function the CodeQL barrier model names — so pin the guard, not the shape
+    // of a comparison that no longer exists.
+    expect(src).toContain('validatePathWithinBase(resolvedFilePath, resolvedProject');
+    expect(src).not.toContain('rootWithSep');
+    // The write must use what the guard returned, never the unvalidated value.
+    expect(src).toContain('fs.writeFileSync(safeFilePath');
+    expect(src).not.toContain('fs.writeFileSync(resolvedFilePath');
   });
 });
 

--- a/scripts/gen-agents-reference.mjs
+++ b/scripts/gen-agents-reference.mjs
@@ -41,7 +41,10 @@ function focus(description) {
   const stop = flat.search(/\.\s|\.$/);
   let sentence = stop > 0 ? flat.slice(0, stop) : flat;
   if (sentence.length > 130) sentence = sentence.slice(0, 127).replace(/\s+\S*$/, '') + '…';
-  return sentence.replace(/\|/g, '\\|');
+  // Backslashes first: escaping `|` with a backslash while leaving existing
+  // backslashes alone turns a description's `\|` into `\\|`, which markdown
+  // renders as a literal backslash followed by a column break.
+  return sentence.replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
 }
 
 function render(agents) {


### PR DESCRIPTION
Closes the five open CodeQL alerts: #474, #475, #613, #614, #615. Three different problems; one is a real defect.

## `codegen.service.ts:548-549` — js/path-injection (#474, #475)

The boundary check was `resolvedFilePath.startsWith(resolvedProject + path.sep)`. Neither side is canonicalised, so an intermediate directory that is a symlink satisfies the prefix and redirects the write outside the project anyway. This is a genuine gap, not a false positive.

Replaced with `validatePathWithinBase(resolvedFilePath, resolvedProject, false)` — the guard the installation pipeline already uses, which realpaths the deepest existing ancestor before deciding and refuses a path it cannot canonicalise. The `mkdirSync`/`writeFileSync` pair uses the value the guard returned. `allowBase: false` because the project root is a directory and a generated file resolving to it exactly is nothing this should attempt.

The alert clearing is a side effect of the strengthening, not the goal.

## `management.service.ts:298,339` — js/path-injection (#614, #615)

False positives of the class `path-sanitizers.model.yml` exists for, with one wrinkle it could not cover: the guard is `assertValidComponentId`, which returned `void`. `js/path-injection` follows the variable, not the call, so an assertion has nothing for `barrierModel` to attach to — and marking `Argument[0]` would not help, because the flow continues from the variable rather than from the call.

It returns the validated id now, and the four call sites in `management.service.ts` assign it back, so every downstream path is built from the checked value. Two entries added to the model.

The claim is a statement of fact, per the criteria the model file sets out for itself: `VALID_COMPONENT_NAME` is `^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$` — no separator, no dot, so the result is a single path segment by construction. A path that did *not* come through it is still reported, which is the class that was genuinely broken in dd0ec86.

Two of the four sites (`agentId`) were not flagged; they are changed anyway, because leaving two of four identical guards in the old shape invites the next reader to copy the wrong one.

## `scripts/gen-agents-reference.mjs:44` — js/incomplete-sanitization (#613)

A real, small bug. `sentence.replace(/\|/g, '\|')` escapes pipes for the markdown table but leaves existing backslashes alone, so a description containing `\|` becomes `\|` — a literal backslash followed by a column break. Backslashes are escaped first now.

No current agent description reaches it: `gen-agents-reference.mjs --check` passes with the README byte-identical. Preventive.

## Test change

`security-hardening.test.ts` R3 asserted that the string `rootWithSep` appears in `codegen.service.ts`. It pinned the shape of the comparison rather than the property, and the comparison is exactly what was replaced. It now asserts the guard is called and that the write uses the guard's return value — and that neither the old variable nor the unvalidated one comes back. R3b (`validation.service.ts`) is untouched; that file still uses the prefix check.

## Verification

Server suite 2526 passed / 1 skipped, `tsc --noEmit` clean, and `audit-mcp-descriptions`, `validate-catalog`, `check-type-sync`, `check-docs-sync`, `gen-capability-matrix --check`, `gen-agents-reference --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
