### PR TITLE
fix(documentation,custom-agents): skip git mode when a technology has no KB directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Security
 
+- **A custom skill's rename target was not confined to the skills directory.**
+  `updateCustomSkill` asserts its `skillId`, but `name` — the rename target —
+  went straight into `path.join` and on to `renameSync` and `writeFileSync`. The
+  update route's Zod pattern rejects a separator, so this was not reachable
+  through the API; the point is that the service was depending on its caller for
+  the guarantee the id assertion beside it exists to state. The computed path now
+  goes through `validatePathWithinBase`, which confines it without re-validating
+  the name, so every name the route accepts keeps working.
 - **A generated file could be written outside the project through a symlinked
   directory.** `codegen.service.ts` confined its writes with
   `resolvedFilePath.startsWith(resolvedProject + path.sep)`, a comparison
@@ -316,7 +324,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   One behaviour change: `list_topics` in git mode no longer enumerates a KB
   directory for `server-performance` and `server-hardening`, whose fake `local`
   pointed into `linux/` and made them answer with the articles `linux-server`
-  owns. (#117)
+  owns. Both now skip git mode outright, on the same rule `fetch_docs` applies
+  per topic — a technology none of whose topics declares a `local` has no KB
+  directory, and going anyway costs a full sparse clone that only fails the
+  directory check afterwards, with nothing caching the failure. (#117)
 - **An install deleted the user's own MCP servers from `.mcp.json`.** The Claude
   Code adapter was the only one that wrote its MCP config without merging, while
   `uninstall.ts` lists that same file under `SHARED_CONFIGS` and un-merges it

--- a/configurator/dashboard/server/src/services/custom-agents.service.ts
+++ b/configurator/dashboard/server/src/services/custom-agents.service.ts
@@ -28,6 +28,7 @@ import { CustomAgentFrontmatterSchema } from '../validation/schemas.js';
 import {
   VALID_COMPONENT_NAME,
   assertValidComponentId,
+  validatePathWithinBase,
 } from './installation/security-helpers.js';
 
 /**
@@ -262,7 +263,7 @@ export class CustomAgentsService {
     if (projectPath.includes('..')) throw new PathValidationError('Path traversal not allowed');
     projectPath = resolveProjectPath(projectPath);
     if (!path.isAbsolute(projectPath)) throw new PathValidationError('Path must be rooted');
-    assertValidComponentId(agentId, 'agent ID');
+    agentId = assertValidComponentId(agentId, 'agent ID');
     const filePath = path.join(this.getCustomAgentsDir(projectPath), `${agentId}.md`);
 
     if (!fs.existsSync(filePath)) {
@@ -403,7 +404,7 @@ export class CustomAgentsService {
     if (projectPath.includes('..')) throw new PathValidationError('Path traversal not allowed');
     projectPath = resolveProjectPath(projectPath);
     if (!path.isAbsolute(projectPath)) throw new PathValidationError('Path must be rooted');
-    assertValidComponentId(agentId, 'agent ID');
+    agentId = assertValidComponentId(agentId, 'agent ID');
     // Check if agent exists
     const existingAgent = await this.getCustomAgent(projectPath, agentId);
     if (!existingAgent) {
@@ -495,7 +496,7 @@ export class CustomAgentsService {
     if (projectPath.includes('..')) throw new PathValidationError('Path traversal not allowed');
     projectPath = resolveProjectPath(projectPath);
     if (!path.isAbsolute(projectPath)) throw new PathValidationError('Path must be rooted');
-    assertValidComponentId(agentId, 'agent ID');
+    agentId = assertValidComponentId(agentId, 'agent ID');
     const filePath = path.join(this.getCustomAgentsDir(projectPath), `${agentId}.md`);
 
     if (!fs.existsSync(filePath)) {
@@ -580,7 +581,7 @@ export class CustomAgentsService {
     if (projectPath.includes('..')) throw new PathValidationError('Path traversal not allowed');
     projectPath = resolveProjectPath(projectPath);
     if (!path.isAbsolute(projectPath)) throw new PathValidationError('Path must be rooted');
-    assertValidComponentId(skillId, 'skill ID');
+    skillId = assertValidComponentId(skillId, 'skill ID');
     const skillDir = path.join(this.getCustomSkillsDir(projectPath), skillId);
     const skillMdPath = path.join(skillDir, 'SKILL.md');
 
@@ -698,7 +699,7 @@ export class CustomAgentsService {
     if (projectPath.includes('..')) throw new PathValidationError('Path traversal not allowed');
     projectPath = resolveProjectPath(projectPath);
     if (!path.isAbsolute(projectPath)) throw new PathValidationError('Path must be rooted');
-    assertValidComponentId(skillId, 'skill ID');
+    skillId = assertValidComponentId(skillId, 'skill ID');
     const skillDir = path.join(this.getCustomSkillsDir(projectPath), skillId);
 
     if (!fs.existsSync(skillDir)) {
@@ -741,7 +742,7 @@ export class CustomAgentsService {
     if (projectPath.includes('..')) throw new PathValidationError('Path traversal not allowed');
     projectPath = resolveProjectPath(projectPath);
     if (!path.isAbsolute(projectPath)) throw new PathValidationError('Path must be rooted');
-    assertValidComponentId(skillId, 'skill ID');
+    skillId = assertValidComponentId(skillId, 'skill ID');
 
     const oldSkillDir = path.join(this.getCustomSkillsDir(projectPath), skillId);
     if (!fs.existsSync(oldSkillDir)) {
@@ -763,7 +764,20 @@ export class CustomAgentsService {
       };
     }
 
-    const newSkillDir = path.join(this.getCustomSkillsDir(projectPath), name);
+    // `skillId` is asserted above, but `name` is the rename *target* and reaches
+    // `renameSync` and `writeFileSync` by exactly the same route. The Zod pattern
+    // on the update route already rejects a separator, so this is defence in
+    // depth rather than a live hole — the point is that the service must not
+    // depend on its caller for that, which is the invariant the id assertion
+    // above exists to state. Confining the computed path rather than
+    // re-validating the name keeps every currently-accepted name working.
+    const skillsDir = this.getCustomSkillsDir(projectPath);
+    let newSkillDir: string;
+    try {
+      newSkillDir = validatePathWithinBase(path.join(skillsDir, name), skillsDir, false);
+    } catch {
+      return { success: false, error: `Invalid skill name '${name}'` };
+    }
     const isRename = skillId !== name;
 
     try {

--- a/configurator/dashboard/server/tests/custom-agents.service.test.ts
+++ b/configurator/dashboard/server/tests/custom-agents.service.test.ts
@@ -976,6 +976,26 @@ Execute directly.
       expect(result.success).toBe(false);
       expect(result.error).toMatch(/already exists/i);
     });
+
+    // `skillId` is asserted at the top of the method; `name` is the rename
+    // target and reaches `renameSync`/`writeFileSync` the same way. The update
+    // route's Zod pattern rejects a separator, so this is the service refusing
+    // to depend on its caller rather than a reachable traversal.
+    it('refuses a rename target that escapes the custom skills directory', async () => {
+      await service.createCustomSkill(projectDir, 'escape-me', validSkillContent(), true);
+      const skillDir = path.join(projectDir, '.claude', 'skills', 'custom', 'escape-me');
+
+      const result = await service.updateCustomSkill(
+        projectDir, 'escape-me', '../../../pwned', validSkillContent(), true
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/invalid skill name/i);
+      // Nothing moved, and nothing was written outside the skills directory.
+      expect(fs.existsSync(skillDir)).toBe(true);
+      expect(fs.existsSync(path.join(projectDir, 'pwned'))).toBe(false);
+      expect(fs.existsSync(path.join(projectDir, '.claude', 'pwned'))).toBe(false);
+    });
   });
 
   // =========================================================================

--- a/mcp-servers/documentation/src/handlers/list-topics.ts
+++ b/mcp-servers/documentation/src/handlers/list-topics.ts
@@ -16,10 +16,20 @@ export const handleListTopics: Handler = async (args, ctx): Promise<HandlerResul
   // omits it — so scan for the first topic that has one instead of trusting
   // whichever happens to be first.
   const entries = Object.values(docsIndex[technology] || {});
-  const kbDir = resolveKbDir(entries.find((e) => e?.local)?.local, technology);
+  const kbLocal = entries.find((e) => e?.local)?.local;
+  const kbDir = resolveKbDir(kbLocal, technology);
+
+  // Same rule `fetch_docs` applies per topic: a technology the index describes,
+  // none of whose topics declares a `local`, has no KB directory to list. Going
+  // to git mode anyway costs a full `git clone --depth 1 --sparse` that only
+  // fails at the `fs.access` check *after* cloning — and nothing caches that
+  // failure, so it is paid again on every call. A technology the index does not
+  // describe at all still tries the key-derived path, which is how a KB
+  // directory the index has not caught up with stays listable.
+  const hasKbArticles = entries.length === 0 || kbLocal !== undefined;
 
   // Git mode - fetch from cached KB
-  if (ctx.kbMode === "git" && ctx.kbFetcher) {
+  if (ctx.kbMode === "git" && ctx.kbFetcher && hasKbArticles) {
     try {
       const files = await ctx.kbFetcher.fetch(kbDir);
       const versions = ctx.versionResolver

--- a/mcp-servers/documentation/tests/git-mode-skip.test.ts
+++ b/mcp-servers/documentation/tests/git-mode-skip.test.ts
@@ -96,4 +96,21 @@ describe("list_topics KB directory resolution", () => {
 
     expect(fetch).toHaveBeenCalledWith("tailwind");
   });
+
+  it("skips the KB for a technology no topic of which declares a local", async () => {
+    // `server-hardening` is a single-topic key with no KB article. Its `local`
+    // used to name a file under `linux/` that never existed — the file was
+    // missing but the *directory* was real, so the fetch succeeded and listed
+    // articles belonging to `linux-server`. With the fake `local` gone, going to
+    // git mode would clone the whole KB only to fail the `fs.access` check, with
+    // nothing caching the failure — once per call.
+    expect(Object.values(docsIndex["server-hardening"]).some((e) => e.local)).toBe(false);
+
+    const { ctx, fetch } = gitCtx();
+    const body = parse(await handleListTopics({ technology: "server-hardening" }, ctx));
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(body.mode).toBe("live_only");
+    expect(body.topics).toEqual(["cis-benchmark"]);
+  });
 });


### PR DESCRIPTION
Two follow-ups from a review of #138 and #139.

## `list_topics` cloned the KB on every call for two technologies

#138 gave `fetch_docs` a `hasKbArticle` guard and removed the fake `local` entries. `list_topics` did not get the equivalent guard, and `server-performance` / `server-hardening` are single-topic keys — so after #138 no topic of theirs declares a `local`, `resolveKbDir` falls back to the technology key, and that directory does not exist in the KB.

`kb-fetcher.ts` finds that out only at step 4, the `fs.access` check — *after* `git clone --depth 1 --filter=blob:none --sparse` (30s timeout), `sparse-checkout set` and `rev-parse`. Nothing caches the failure, so the clone is repeated on every call before the handler falls through to the live topic list.

Before #138 the fake `local` pointed at `linux/`, which does exist, so the fetch succeeded — and answered `list_topics("server-hardening")` with the three articles `linux-server` owns. Wrong, but cheap. Neither state is right; both are now skipped outright, on the same rule `fetch_docs` applies per topic:

- a technology the index describes, none of whose topics declares a `local`, has no KB directory → skip git mode
- a technology the index does not describe at all → still tries the key-derived path, which is how a KB directory the index has not caught up with stays listable

This is the same waste #138 set out to remove, so it should not have been left in the handler next door.

## `updateCustomSkill` built its rename target from an unasserted name

The method asserts `skillId` and then does `path.join(getCustomSkillsDir(projectPath), name)`, reaching `renameSync` and `writeFileSync`. `name` was never validated in the service.

**Not reachable through the API** — `UpdateCustomSkillRequestSchema` constrains `name` with `^[a-z0-9-]+$`, which has no separator and no dot. What is wrong is that the service depended on its caller for the guarantee the assertion one line above exists to state, in the file whose `DELETE /api/custom-skills/..%2F..%2Fsrc` traversal is the reason that assertion was added.

The computed path now goes through `validatePathWithinBase`. Confining the path rather than re-running the id pattern on `name` is deliberate: `agentNamePattern` (`^[a-z0-9-]+$`) and `VALID_COMPONENT_NAME` (`^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$`) disagree on a leading hyphen, so asserting the name would have rejected names the route accepts.

## Consistency

The six `assertValidComponentId` call sites in `custom-agents.service.ts` now assign the validated id back, like the four in `management.service.ts`. **No CodeQL alert was ever raised on this file** — 0 in any state — so this is not an alert fix; it makes the claim in `path-sanitizers.model.yml` ("the callers that build a path assign it back") true of the repo rather than of one file, and stops the next reader copying the shape that the barrier model cannot attach to.

## Tests

- `git-mode-skip.test.ts`: `list_topics("server-hardening")` never touches `kbFetcher` and returns the live topic list.
- `custom-agents.service.test.ts`: a `../../../pwned` rename target is refused, the skill directory is untouched, and nothing is written outside the skills directory.

Server suite 2536 passed / 1 skipped (86 files), documentation suite 94 passed, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
