### PR TITLE
ci: run the test workflows on Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dashboard dependencies
         run: npm ci

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dashboard dependencies
         run: npm ci


### PR DESCRIPTION
## Why

PR #166 (jsdom 24 → 30) fails CI with 29 unhandled errors, and not one test runs:

```
Vitest caught 29 unhandled errors during the test run.
Error: [vitest-pool]: Failed to start forks worker for test files ...
Caused by: TypeError: webidl.util.markAsUncloneable is not a function
```

It reads as a jsdom incompatibility. It is not.

jsdom 30 pulls in **undici 8.10.1**, which calls `worker_threads.markAsUncloneable`. That API is absent from the **Node 20** these workflows pin, so every Vitest worker dies during environment setup.

## Evidence

Checked out the same jsdom 30 branch and ran the frontend suite on Node 22.22.0:

```
Test Files  29 passed (29)
     Tests  403 passed | 5 skipped (408)
FRONTEND TEST EXIT: 0
```

Same code, same jsdom, same vitest — only the runner changed, and the suite passes whole.

Node 20 is deprecated on GitHub Actions independently of this: every run already logs *"Node 20 is being deprecated. This workflow is running with Node 24 by default"*, so the actions were being forced off it anyway.

## Scope

`ci.yml` and `e2e.yml` only.

**`release.yml` deliberately stays on Node 20.** It builds the installers shipped to users across three runners; moving that toolchain deserves validation behind an `rc` tag, not a silent ride-along with a test fix.

## Follow-up

With this merged, #166 should go green and become mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zdcEoMnLUwX5kqE1hyhWu
