### PR TITLE
chore(deps-dev): bump tsx to 4.23.13 in /mcp-servers

### DIFF
--- a/mcp-servers/log-analyzer/package.json
+++ b/mcp-servers/log-analyzer/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@types/node": "^26.4.1",
     "typescript": "^5.3.0",
-    "tsx": "^4.22.4",
+    "tsx": "^4.23.13",
     "vitest": "^4.1.11"
   },
   "engines": {

--- a/mcp-servers/package-lock.json
+++ b/mcp-servers/package-lock.json
@@ -30,7 +30,7 @@
       "devDependencies": {
         "@types/node": "^26.4.1",
         "esbuild": "^0.28.2",
-        "tsx": "^4.22.4",
+        "tsx": "^4.23.13",
         "typescript": "^5.3.0",
         "vitest": "^4.1.11"
       }
@@ -171,7 +171,7 @@
       },
       "devDependencies": {
         "@types/node": "^26.4.1",
-        "tsx": "^4.22.4",
+        "tsx": "^4.23.13",
         "typescript": "^5.3.0",
         "vitest": "^4.1.11"
       },
@@ -6254,9 +6254,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
-      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "version": "4.23.13",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.13.tgz",
+      "integrity": "sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/mcp-servers/package.json
+++ b/mcp-servers/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@types/node": "^26.4.1",
     "esbuild": "^0.28.2",
-    "tsx": "^4.22.4",
+    "tsx": "^4.23.13",
     "typescript": "^5.3.0",
     "vitest": "^4.1.11"
   },


### PR DESCRIPTION
Supersedes #170.

## Why a replacement PR

#170 has been correct since it opened and never got to land. It touches `mcp-servers/package-lock.json`, and so did every other `mcp-servers` bump merged today — each merge re-conflicted it. After the last few rounds Dependabot stopped acting on `@dependabot rebase` and the branch sat at `b79310e2`.

## Why applied by hand

npm 10 (this machine) does not write the `libc` fields that npm 11 adds to optional platform binaries; the committed lockfile has ten of them, generated by CI's newer npm. Regenerating the lockfile locally would have silently dropped all ten and weakened platform filtering for anyone installing on Linux — a real regression smuggled in behind a devDependency bump.

The change is small enough that regeneration is not needed:

- 4 dependency ranges (`mcp-servers/package.json`, `mcp-servers/log-analyzer/package.json`, and their two mirrors in the lockfile's `packages` entries)
- 1 `node_modules/tsx` entry — `version`, `resolved`, `integrity`

Identical in effect to what #170 proposed. Verified afterwards that the lockfile still parses and that all ten `libc` fields survive.

`tsx` is a dev-only TypeScript runner used by the `dev` and `test` scripts; nothing shipped depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zdcEoMnLUwX5kqE1hyhWu
