### PR TITLE
release(v1.14.0-rc.1): committable installs, sixteen verified dependency updates, Node 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: configurator/dashboard/package-lock.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-09-05
+
 ### Changed
 
 - **A dev-suite install is now committable, so a clone arrives working.** The
@@ -52,6 +54,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   and ~7.8 MB for `skill-loader`, most of which is the markdown skill payload
   that lazy loading exists to serve.
 
+- **Fifteen pending dependency updates applied as one verified batch**, across
+  `mcp-servers`, the dashboard and the dashboard server. Notably TypeScript
+  5.9.3 → 7.0.2: the new compiler removed `baseUrl`, and the server's `paths`
+  were already written relative to the config, so dropping it leaves module
+  resolution unchanged.
+
+- **A second batch of fifteen dependency updates**, this time including six
+  major bumps, each verified rather than taken on faith: Electron 40 → 44,
+  jsdom 24 → 30, zod 3 → 4 across nine MCP servers, `@types/node` 25 → 26,
+  `open` 10 → 11 and the Claude Agent SDK 0.2 → 0.3.
+
+  Two needed more than a version change. **zod 4 removed the single-argument
+  `z.record(valueSchema)` overload** — the key schema is now mandatory, so
+  `z.record(z.string())` read its lone argument as the *key* type and inferred
+  an unknown value type, breaking the build of `api-tester` and
+  `performance-profiler`. All six call sites meant `Record<string, string>`
+  (HTTP headers, template variables) and now say so explicitly.
+
+  **Electron was verified by building the installer, not by CI**, which runs no
+  Electron step at all: a green pipeline says nothing about the desktop app.
+  The NSIS build produces the full Windows artifact set on 44.
+
 ### Fixed
 
 - **Two callers could hold the same knowledge-base clone lock.** Judging a lock
@@ -67,20 +91,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   serialised by a marker created *inside* the lock — winning it proves we hold
   the directory we judged rather than merely its name.
 
-### Changed
-
-- **Fifteen pending dependency updates applied as one verified batch**, across
-  `mcp-servers`, the dashboard and the dashboard server. Notably TypeScript
-  5.9.3 → 7.0.2: the new compiler removed `baseUrl`, and the server's `paths`
-  were already written relative to the config, so dropping it leaves module
-  resolution unchanged.
-
 ### Internal
 
 - **The `e2e` status check was required but could never report.** It was moved
   off the PR gate in #65 and left as `workflow_dispatch`, while the branch
   ruleset went on requiring it — so every pull request since sat in `BLOCKED`
   regardless of its CI. Removed from the required checks; E2E stays manual.
+
+- **The test workflows moved to Node 22.** `jsdom` 30 pulls in `undici` 8,
+  which calls `worker_threads.markAsUncloneable` — absent from the Node 20 the
+  workflows pinned, so every Vitest worker died during setup with
+  `TypeError: webidl.util.markAsUncloneable is not a function`. It read as a
+  jsdom incompatibility and was not one: the same branch on Node 22 passes the
+  frontend suite whole. Node 20 was deprecated on GitHub Actions regardless —
+  every run already logged that the actions were being forced onto Node 24.
 
 ## [1.13.0] - 2026-09-02
 

--- a/configurator/dashboard/package.json
+++ b/configurator/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev-suite/dashboard",
-  "version": "1.13.0",
+  "version": "1.14.0-rc.1",
   "private": true,
   "type": "module",
   "description": "Dev-Suite Dashboard: visual project configuration and multi-agent orchestration for Claude Code.",

--- a/configurator/dashboard/server/package.json
+++ b/configurator/dashboard/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev-suite/dashboard-server",
-  "version": "1.13.0",
+  "version": "1.14.0-rc.1",
   "description": "Dev-Suite Dashboard Backend Server",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release candidate for **1.14.0**. Cut as an `rc` for one specific reason: this is the first release built on **Node 22**.

`ci.yml` and `e2e.yml` moved to Node 22 in #174, once jsdom 30 proved the runner was the blocker rather than the dependency. `release.yml` deliberately stayed on Node 20 — it produces the installers shipped to users across three runners, and that toolchain warrants a validated tag rather than a silent ride-along with a test fix. **This RC is that validation.**

## Version

`1.13.0` → `1.14.0` (MINOR). A dev-suite install becomes committable, which is a new user-facing capability. Nothing existing breaks: an install regenerates its own config.

Both `configurator/dashboard/package.json` and `configurator/dashboard/server/package.json` carry `1.14.0-rc.1`, so the artifacts are identifiable as a candidate. Promoting to stable is a second version bump.

## What's in it

**Committable installs (#173).** Generated MCP config carried absolute paths while `.mcp-servers/` — the bundles those paths pointed at — was unconditionally gitignored. The file that *was* committed pointed at a directory that never was, so every teammate's clone had servers that could not connect. Paths now render with each surface's *confirmed* project-root token, `secret: true` env vars render as references to the ambient variable, and the bundles are committed.

**Sixteen dependency updates**, six major, each verified rather than assumed. Two needed real work:

- **zod 3 → 4** removed the single-argument `z.record(valueSchema)` overload; the key schema is now mandatory, so `z.record(z.string())` read its lone argument as the *key* type. Six call sites across two servers fixed.
- **Electron 40 → 44** was verified by building the NSIS installer locally, because CI runs no Electron step at all — a green pipeline says nothing about the desktop app. Full Windows artifact set produced on 44.

## Verification so far

- 2746 tests pass across 97 files, `tsc --noEmit` clean
- All 8 CI gates green
- Windows installer built locally on Electron 44 + Node 22

## What this RC is for

The macOS and Linux runners. Those artifacts have never been built on Node 22, and only the release workflow builds them. Checking the matrix goes green on all three, and that the published assets carry the full set:

- Windows — `*Setup*.exe`, `.blockmap`, `latest.yml`
- macOS — `*-arm64.dmg`, `*-x64.dmg` (+ blockmaps), `latest-mac.yml`
- Linux — `*.AppImage`, `*.deb`, `latest-linux.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zdcEoMnLUwX5kqE1hyhWu
