### PR TITLE
feat(docs): index the analyser references the review skills lean on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Authoritative analyser references behind the `review/*` skills.** Each
+  review skill carries a table of what the toolchain already reports, and that
+  half is the one that dates: a rule moves in or out of a default set with the
+  tool, not with us. Only three of the eleven languages had anything in the
+  documentation index backing it — `ruff`, `eslint` and `clang-tidy`.
+
+  Added `go-quality`, `rust-quality`, `java-quality`, `dotnet-quality`,
+  `kotlin-quality` and `swift-quality`, extended `cpp-quality` with the GCC
+  warning set and the sanitizers, `ruff` with `settings` (where `select` is
+  decided), and `typescript` with `tsconfig` — the two settings that matter most
+  for review, `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes`, are
+  not in `strict`.
+
+  Every new entry is **live-only** on purpose. `DocEntry.local` is what makes
+  `fetch_docs` attempt a sparse checkout, so naming a file the knowledge base
+  never wrote costs a failed checkout and an error log on every request. More
+  to the point: these indexes are maintained and versioned by the tool authors,
+  and a copy of ours would diverge from the tool the reader is running — the one
+  thing that must not happen when the question is "did the linter already report
+  this?". The pinned live-only list in `tests/docs-index.test.ts` is updated
+  accordingly, which is that guard working as designed.
+
+  Each skill now points at its index from directly under the table, so the
+  reader can check the version their project pins rather than the one the skill
+  was written against.
+
 ### Fixed
 
 - **An `-rc` tag published as a stable release, and the updater offered it.**

--- a/mcp-servers/documentation/src/docs-index/languages.ts
+++ b/mcp-servers/documentation/src/docs-index/languages.ts
@@ -48,6 +48,12 @@ export const languageDocs: DocsRecord = {
       local: "typescript/generics.md",
       url: "https://www.typescriptlang.org/docs/handbook/2/generics.html",
     },
+    // The compiler's strictness is a setting, and the two that matter most for
+    // review are NOT in `strict`: `noUncheckedIndexedAccess` (so `rows[0]` is
+    // typed as present) and `exactOptionalPropertyTypes`.
+    tsconfig: {
+      url: "https://www.typescriptlang.org/tsconfig/",
+    },
     "utility-types": {
       local: "typescript/utility-types.md",
       url: "https://www.typescriptlang.org/docs/handbook/utility-types.html",

--- a/mcp-servers/documentation/src/docs-index/tooling.ts
+++ b/mcp-servers/documentation/src/docs-index/tooling.ts
@@ -22,6 +22,18 @@ export const TOOLING_TECHNOLOGIES = [
   "eslint",
   "cpp-quality",
   "ruff",
+  // Static analysis, per language. These back the "already covered by the
+  // toolchain" half of the `review/*` skills, which is the half that goes stale
+  // — a rule moves in or out of a default set with the tool, not with us. The
+  // entries are deliberately live-only (no `local`): the rule indexes are
+  // maintained by the tool authors, and a copy of ours would age faster than
+  // the skill it supports.
+  "go-quality",
+  "rust-quality",
+  "java-quality",
+  "dotnet-quality",
+  "kotlin-quality",
+  "swift-quality",
   // Validation
   "zod",
   "yup",
@@ -117,6 +129,12 @@ export const toolingDocs: DocsRecord = {
     rules: {
       local: "ruff/rules.md",
       url: "https://docs.astral.sh/ruff/rules/",
+    },
+    // Where `select` is set. The default is `E4, E7, E9, F` — far narrower
+    // than ruff's reputation — so whether B006, DTZ and ASYNC findings are the
+    // linter's job or the reviewer's is decided in this file.
+    settings: {
+      url: "https://docs.astral.sh/ruff/settings/",
     },
   },
 
@@ -312,6 +330,93 @@ export const toolingDocs: DocsRecord = {
     },
   },
 
+  // --- Static analysis, per language ------------------------------------
+  // Every entry here is live-only on purpose. These are rule indexes the tool
+  // authors maintain and version; a KB copy would diverge from the tool the
+  // reader is actually running, which is the one thing that must not happen
+  // when the question is "did the linter already report this?".
+
+  "go-quality": {
+    "go-vet": {
+      url: "https://pkg.go.dev/cmd/vet",
+    },
+    "staticcheck-checks": {
+      url: "https://staticcheck.dev/docs/checks/",
+    },
+    "golangci-lint-linters": {
+      url: "https://golangci-lint.run/usage/linters/",
+    },
+  },
+
+  "rust-quality": {
+    "clippy-lints": {
+      url: "https://rust-lang.github.io/rust-clippy/master/",
+    },
+    "rustc-lints": {
+      url: "https://doc.rust-lang.org/rustc/lints/listing/index.html",
+    },
+    // Where `overflow-checks` lives: on in debug, off in release, which is why
+    // an unsigned subtraction panics under `cargo test` and wraps in the
+    // binary users run.
+    "cargo-profiles": {
+      url: "https://doc.rust-lang.org/cargo/reference/profiles.html",
+    },
+  },
+
+  "java-quality": {
+    "spotbugs-bug-descriptions": {
+      url: "https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html",
+    },
+    "errorprone-bugpatterns": {
+      url: "https://errorprone.info/bugpatterns",
+    },
+    nullaway: {
+      url: "https://github.com/uber/NullAway/wiki",
+    },
+    // `-Xlint` is the only analysis a plain build runs; the three above are
+    // separate build steps a Spring Boot starter does not have.
+    "javac-xlint": {
+      url: "https://docs.oracle.com/en/java/javase/21/docs/specs/man/javac.html",
+    },
+  },
+
+  "dotnet-quality": {
+    "code-analysis-rules": {
+      url: "https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/",
+    },
+    "nullable-reference-types": {
+      url: "https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references",
+    },
+  },
+
+  "kotlin-quality": {
+    detekt: {
+      url: "https://detekt.dev/",
+    },
+    "detekt-configuration": {
+      url: "https://detekt.dev/docs/introduction/configurations",
+    },
+    // The rule family that matters for review; detekt has no single rules
+    // index page, the categories are separate documents.
+    "detekt-potential-bugs": {
+      url: "https://detekt.dev/docs/rules/potential-bugs",
+    },
+    "detekt-suppressing": {
+      url: "https://detekt.dev/docs/introduction/suppressing-rules",
+    },
+  },
+
+  "swift-quality": {
+    "swiftlint-rules": {
+      url: "https://realm.github.io/SwiftLint/rule-directory.html",
+    },
+    // Whether the data-race findings are compile errors or review findings is
+    // decided here, not by the language version alone.
+    "swift-6-migration": {
+      url: "https://www.swift.org/migration/documentation/migrationguide/",
+    },
+  },
+
   "cpp-quality": {
     "clang-tidy": {
       local: "cpp-quality/clang-tidy.md",
@@ -324,6 +429,20 @@ export const toolingDocs: DocsRecord = {
     "clang-format": {
       local: "cpp-quality/clang-format.md",
       url: "https://clang.llvm.org/docs/ClangFormat.html",
+    },
+    // The warning set itself, which is OFF by default: a CMake project that
+    // never sets `-Wall -Wextra` compiles almost silently, and then every
+    // "already covered" row in `review/cpp` moves into the reviewer's column.
+    "gcc-warning-options": {
+      url: "https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html",
+    },
+    // Sanitizers catch most lifetime defects — but only on executed paths, so
+    // an untested branch is exactly where they survive.
+    "address-sanitizer": {
+      url: "https://clang.llvm.org/docs/AddressSanitizer.html",
+    },
+    "undefined-behavior-sanitizer": {
+      url: "https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html",
     },
     "clang-format-style": {
       local: "cpp-quality/clang-format-style.md",

--- a/mcp-servers/documentation/tests/docs-index.test.ts
+++ b/mcp-servers/documentation/tests/docs-index.test.ts
@@ -93,7 +93,29 @@ describe('docs-index', () => {
 
       expect(localless.sort()).toEqual([
         'bulk-engineering/namur-ne150',
+        // Static-analysis rule indexes. Live-only by design: they are
+        // maintained and versioned by the tool authors, and they back the
+        // "already covered by the toolchain" half of the `review/*` skills.
+        // A KB copy would diverge from the tool the reader is running, which
+        // is the one thing that must not happen when the question is "did the
+        // linter already report this?".
+        'cpp-quality/address-sanitizer',
+        'cpp-quality/gcc-warning-options',
+        'cpp-quality/undefined-behavior-sanitizer',
+        'dotnet-quality/code-analysis-rules',
+        'dotnet-quality/nullable-reference-types',
         'github-actions/actions',
+        'go-quality/go-vet',
+        'go-quality/golangci-lint-linters',
+        'go-quality/staticcheck-checks',
+        'java-quality/errorprone-bugpatterns',
+        'java-quality/javac-xlint',
+        'java-quality/nullaway',
+        'java-quality/spotbugs-bug-descriptions',
+        'kotlin-quality/detekt',
+        'kotlin-quality/detekt-configuration',
+        'kotlin-quality/detekt-potential-bugs',
+        'kotlin-quality/detekt-suppressing',
         'mongodb/aggregation',
         'mongodb/indexes',
         'mongodb/queries',
@@ -103,9 +125,16 @@ describe('docs-index', () => {
         'pinia/composables',
         'redis/commands',
         'redis/patterns',
+        'ruff/settings',
+        'rust-quality/cargo-profiles',
+        'rust-quality/clippy-lints',
+        'rust-quality/rustc-lints',
         'server-hardening/cis-benchmark',
         'server-performance/linux-performance-tuning',
+        'swift-quality/swift-6-migration',
+        'swift-quality/swiftlint-rules',
         'tailwindcss/spacing',
+        'typescript/tsconfig',
         'vite/basics',
         'vite/build',
         'vite/env-variables',

--- a/skills/review/cpp/SKILL.md
+++ b/skills/review/cpp/SKILL.md
@@ -52,6 +52,12 @@ clang-tidy target and no sanitizer preset, then rows 1-9 are all yours. That is
 one comment about the build, followed by the specific instances — not a
 per-line campaign.
 
+> **The table above dates; the tools do not.** Verify a default set with
+> `mcp__documentation__fetch_docs` on technology `cpp-quality` — topics `gcc-warning-options`, `clang-tidy-checks`, `address-sanitizer`, `undefined-behavior-sanitizer`.
+> Those entries point at the indexes the tool authors maintain, so they follow
+> the version the project actually pins rather than the one this skill was
+> written against.
+
 ## The checks that earn their place
 
 ### A guard that guards nothing

--- a/skills/review/csharp/SKILL.md
+++ b/skills/review/csharp/SKILL.md
@@ -43,6 +43,12 @@ The snippets are fragments cut down to the defect, not runnable programs.
 nullable disabled has no null guarantees whatsoever, and that is one
 architectural comment, not a per-line campaign.
 
+> **The table above dates; the tools do not.** Verify a default set with
+> `mcp__documentation__fetch_docs` on technology `dotnet-quality` — topics `code-analysis-rules`, `nullable-reference-types`.
+> Those entries point at the indexes the tool authors maintain, so they follow
+> the version the project actually pins rather than the one this skill was
+> written against.
+
 ## The checks that earn their place
 
 ### `async void` outside an event handler

--- a/skills/review/go/SKILL.md
+++ b/skills/review/go/SKILL.md
@@ -38,6 +38,12 @@ The snippets are fragments cut down to the defect, not runnable programs.
 If the project has no linter configured, that is one review comment about CI —
 not thirty comments doing the linter's job by hand.
 
+> **The table above dates; the tools do not.** Verify a default set with
+> `mcp__documentation__fetch_docs` on technology `go-quality` — topics `go-vet`, `staticcheck-checks`, `golangci-lint-linters`.
+> Those entries point at the indexes the tool authors maintain, so they follow
+> the version the project actually pins rather than the one this skill was
+> written against.
+
 ## The checks that earn their place
 
 ### A typed nil in an interface is not a nil interface

--- a/skills/review/java/SKILL.md
+++ b/skills/review/java/SKILL.md
@@ -44,6 +44,12 @@ absent — and in a plain Spring Boot starter they are — then rows 5 through 8
 review findings, not tool findings. That is one comment about the build, plus
 the specific instances.
 
+> **The table above dates; the tools do not.** Verify a default set with
+> `mcp__documentation__fetch_docs` on technology `java-quality` — topics `spotbugs-bug-descriptions`, `errorprone-bugpatterns`, `javac-xlint`, `nullaway`.
+> Those entries point at the indexes the tool authors maintain, so they follow
+> the version the project actually pins rather than the one this skill was
+> written against.
+
 ## The checks that earn their place
 
 ### An `Optional` that reintroduces the null it replaced

--- a/skills/review/kotlin/SKILL.md
+++ b/skills/review/kotlin/SKILL.md
@@ -39,6 +39,12 @@ Kotlin projects vary more than most in whether detekt runs at all. Check
 `build.gradle.kts` for the plugin and for `detekt.yml`, because the `!!` and
 swallowed-exception rows flip sides depending on it.
 
+> **The table above dates; the tools do not.** Verify a default set with
+> `mcp__documentation__fetch_docs` on technology `kotlin-quality` — topics `detekt-potential-bugs`, `detekt-configuration`, `detekt-suppressing`.
+> Those entries point at the indexes the tool authors maintain, so they follow
+> the version the project actually pins rather than the one this skill was
+> written against.
+
 ## The checks that earn their place
 
 ### A platform type from Java, trusted as non-null

--- a/skills/review/python/SKILL.md
+++ b/skills/review/python/SKILL.md
@@ -46,6 +46,12 @@ If a project pins ruff to the default set, the four opt-in rows above are
 **your** job. Establish which it is by reading the config, once, rather than
 guessing per file.
 
+> **The table above dates; the tools do not.** Verify a default set with
+> `mcp__documentation__fetch_docs` on technology `ruff` — topics `rules`, `settings` (where `select` is decided).
+> Those entries point at the indexes the tool authors maintain, so they follow
+> the version the project actually pins rather than the one this skill was
+> written against.
+
 ## The checks that earn their place
 
 ### A coroutine created and never awaited

--- a/skills/review/rust/SKILL.md
+++ b/skills/review/rust/SKILL.md
@@ -45,6 +45,12 @@ Clippy's default set is broad and on in most CI. Before commenting, assume it
 ran; check `#![allow(...)]` at crate root and `clippy.toml` for what was
 switched off, because that is where the interesting exemptions hide.
 
+> **The table above dates; the tools do not.** Verify a default set with
+> `mcp__documentation__fetch_docs` on technology `rust-quality` — topics `clippy-lints`, `rustc-lints`, `cargo-profiles`.
+> Those entries point at the indexes the tool authors maintain, so they follow
+> the version the project actually pins rather than the one this skill was
+> written against.
+
 ## The checks that earn their place
 
 ### `RefCell` moving an aliasing error to runtime

--- a/skills/review/swift/SKILL.md
+++ b/skills/review/swift/SKILL.md
@@ -40,6 +40,12 @@ The last row is the one that matters most. In Swift 5 mode with minimal
 concurrency checking, every concurrency finding below is unreported. Establish
 the target's setting before deciding.
 
+> **The table above dates; the tools do not.** Verify a default set with
+> `mcp__documentation__fetch_docs` on technology `swift-quality` — topics `swiftlint-rules`, `swift-6-migration`.
+> Those entries point at the indexes the tool authors maintain, so they follow
+> the version the project actually pins rather than the one this skill was
+> written against.
+
 ## The checks that earn their place
 
 ### A closure capturing `self` strongly and outliving the call

--- a/skills/review/typescript/SKILL.md
+++ b/skills/review/typescript/SKILL.md
@@ -45,6 +45,12 @@ they need `parserOptions.project`, and many repos never enable it. If they are
 off, floating promises **are** worth reviewing by hand - that is a config
 finding plus a code finding, not one comment.
 
+> **The table above dates; the tools do not.** Verify a default set with
+> `mcp__documentation__fetch_docs` on technology `eslint` — topics `rules`, `typescript-eslint` — and `typescript`/`tsconfig` for the compiler settings.
+> Those entries point at the indexes the tool authors maintain, so they follow
+> the version the project actually pins rather than the one this skill was
+> written against.
+
 ## The checks that earn their place
 
 ### A type assertion that launders a lie


### PR DESCRIPTION
Tier 1 of the knowledge-base analysis for the `review/*` skills.

## The gap

Each review skill has two halves. The **checks** are judgement and stable. The table of **what the toolchain already reports** is the half that dates — a rule moves in or out of a default set with the tool, not with us — and it is the half consulted on every review to decide whether to stay silent.

Only three of the eleven languages had anything in the documentation index backing it: `ruff`, `eslint`, `clang-tidy`.

## What was added

| Technology | Backs |
|---|---|
| `go-quality` | `go vet`, staticcheck, golangci-lint default linters |
| `rust-quality` | clippy, rustc lints, **cargo profiles** — where `overflow-checks` on-in-debug/off-in-release lives |
| `java-quality` | SpotBugs, Error Prone, NullAway, and `javac -Xlint` (the only analysis a plain build runs) |
| `dotnet-quality` | CA rules, nullable reference types |
| `kotlin-quality` | detekt: configuration, `potential-bugs`, suppressing |
| `swift-quality` | SwiftLint rule directory, Swift 6 migration guide |
| `cpp-quality` *(extended)* | GCC warning options + ASan + UBSan — warnings are **off by default**, which is what moves that whole table into the reviewer's column |
| `ruff` *(extended)* | `settings`, where `select` is decided |
| `typescript` *(extended)* | `tsconfig` — `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes` are **not** in `strict` |

## Why every entry is live-only

Two reasons, and both are in the code:

1. `DocEntry.local` is what makes `fetch_docs` attempt a sparse checkout. Naming a file the KB never wrote costs a failed checkout and an error log **per request** — the type's own doc comment says so.
2. These indexes are maintained and versioned by the tool authors. A copy of ours would diverge from the tool the reader is actually running, which is the one thing that must not happen when the question is *"did the linter already report this?"*.

So **no knowledge-base repository changes**: Tier 1 adds references, not articles. Nothing was cloned, nothing needs pushing there, and `ls knowledge` confirms nothing leaked into this repo.

## The guard did its job

`tests/docs-index.test.ts` pins the live-only list precisely so one cannot appear by someone forgetting the field. It failed, correctly, and is updated with the twenty-three deliberate additions.

## URLs were verified, not asserted

All 15 candidates checked before landing. Two did not survive:

- `https://detekt.dev/docs/rules/` → **404**. detekt has no single rules index; the categories are separate documents, so `potential-bugs` is the entry point.
- ktlint's `pinterest.github.io` site → **404**, the project moved. Omitted rather than guessed at.

## Discoverability

Each skill now points at its index from directly under the table, so a reader can check the version their project pins rather than the one the skill was written against. Follows the `languages/*` precedent of naming `fetch_docs` in the body.

## Verification

Documentation server builds; its suite passes 141/141. All 8 CI gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zdcEoMnLUwX5kqE1hyhWu
