### PR TITLE
feat(docs): register the three KB-only review articles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Three knowledge-base articles that no upstream publishes**, registered as
+  KB-only entries (`local`, no `url`). Tier 1 added references to indexes the
+  tool authors maintain; these are the cases where following that rule would
+  mean pointing at nothing, because the comparison itself is the content.
+
+  `code-review/default-analysis-by-language` — what each language's toolchain
+  reports out of the box, ordered by how much of the review is already done for
+  you. Rust at one end, where restraint is the skill; SQL at the other, where
+  the reviewer *is* the analysis. Each section names the config file to read,
+  because the same finding is essential or noise depending on one line of it.
+
+  `sql-fundamentals/engine-differences` — the differences that change what a
+  query *means*: REPEATABLE READ on MySQL against READ COMMITTED everywhere
+  else, `UNIQUE` accepting one NULL on SQL Server and many elsewhere, Oracle
+  treating `''` as NULL, MySQL's case-insensitive default collation, and which
+  DDL rewrites a table or blocks writes.
+
+  `nodejs/runtime-failure-modes` — the failures that produce no error, no
+  warning and no failed test. Including the two that only fail *outside*
+  development, which local testing actively confirms as working: `process.exit()`
+  truncates stdout when it is a pipe rather than a TTY, so a CLI loses its output
+  exactly when used in a script; and module-scope state is per process, so under
+  `cluster` a rate limiter allows N times its limit and a lock locks nothing.
+
+  `tests/fetch-docs-live.test.ts` pins the url-less list for the same reason its
+  sibling pins the local-less one — a KB-only entry must be a deliberate act,
+  not a forgotten field. It failed correctly and is updated.
+
 - **Authoritative analyser references behind the `review/*` skills.** Each
   review skill carries a table of what the toolchain already reports, and that
   half is the one that dates: a rule moves in or out of a default set with the

--- a/mcp-servers/documentation/src/docs-index/databases.ts
+++ b/mcp-servers/documentation/src/docs-index/databases.ts
@@ -283,6 +283,12 @@ export const databaseDocs: DocsRecord = {
       local: "sql-fundamentals/transactions.md",
       url: "https://www.postgresql.org/docs/current/mvcc.html",
     },
+    // Cross-vendor, so KB-only: each engine documents itself and none
+    // documents the comparison. Default isolation, UNIQUE with NULLs,
+    // collation case-sensitivity and which DDL rewrites a table.
+    "engine-differences": {
+      local: "sql-fundamentals/engine-differences.md",
+    },
   },
 
   oracle: {

--- a/mcp-servers/documentation/src/docs-index/languages.ts
+++ b/mcp-servers/documentation/src/docs-index/languages.ts
@@ -61,6 +61,11 @@ export const languageDocs: DocsRecord = {
   },
 
   nodejs: {
+    // KB-only: the set is defined by the ABSENCE of a diagnostic, so it is
+    // not a feature any page documents.
+    "runtime-failure-modes": {
+      local: "nodejs/runtime-failure-modes.md",
+    },
     "event-loop": {
       local: "nodejs/event-loop.md",
       url: "https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick",

--- a/mcp-servers/documentation/src/docs-index/standards.ts
+++ b/mcp-servers/documentation/src/docs-index/standards.ts
@@ -10,6 +10,7 @@ export const STANDARDS_TECHNOLOGIES = [
   // Best Practices
   "git-workflow",
   "clean-code",
+  "code-review",
   "performance",
   // Security
   "owasp",
@@ -25,6 +26,16 @@ export const STANDARDS_TECHNOLOGIES = [
 ] as const;
 
 export const standardsDocs: DocsRecord = {
+  // No `url`: nobody publishes the cross-language comparison, because no
+  // vendor benefits from stating how much their defaults leave out. Pointing
+  // at a loosely related tool page would assert an authority that does not
+  // exist, so this is served from the knowledge base only.
+  "code-review": {
+    "default-analysis-by-language": {
+      local: "code-review/default-analysis-by-language.md",
+    },
+  },
+
   "git-workflow": {
     commands: {
       local: "git-workflow/commands.md",

--- a/mcp-servers/documentation/tests/fetch-docs-live.test.ts
+++ b/mcp-servers/documentation/tests/fetch-docs-live.test.ts
@@ -50,7 +50,15 @@ describe("fetch_docs live fallback for KB-only topics", () => {
       "abb-freelance/dmf-format",
       "abb-freelance/prt-format",
       "bulk-engineering/python-generation",
+      // Written for the `review/*` skills. Each is KB-only because the
+      // comparison it makes is one no vendor publishes: tool authors
+      // document their own rules, engines document their own behaviour,
+      // and a set defined by the ABSENCE of a diagnostic is not a feature
+      // any page describes.
+      "code-review/default-analysis-by-language",
       "dcs-platforms/overview",
+      "nodejs/runtime-failure-modes",
+      "sql-fundamentals/engine-differences",
     ]);
   });
 });


### PR DESCRIPTION
Tier 2, after #189. Articles written and pushed to the knowledge base as [`a7ada5c`](https://github.com/claude-dev-suite/knowledge_base/commit/a7ada5c); this PR registers them in the index.

## Why these three are written rather than referenced

Tier 1's rule was: point at the index the tool authors maintain, never copy it. These three are the cases where following that rule would mean pointing at nothing — **the comparison itself is the content**, and no vendor has a reason to publish it.

So they are the mirror of Tier 1: `local`, no `url`.

| Article | Why no upstream |
|---|---|
| `code-review/default-analysis-by-language` | Every tool documents its own rules; nobody documents how much their defaults leave out |
| `sql-fundamentals/engine-differences` | Each engine documents itself; none documents the comparison |
| `nodejs/runtime-failure-modes` | The set is defined by the *absence* of a diagnostic, so it is not a feature any page describes |

## What they contain

**`default-analysis-by-language`** orders the languages by how much of the review is already done for you — Rust at one end, where restraint is the skill, SQL at the other, where the reviewer *is* the analysis. Each section names the config file to read, because the same finding is essential or noise depending on one line of it.

**`engine-differences`** covers what changes a query's *meaning*: REPEATABLE READ on MySQL against READ COMMITTED everywhere else; `UNIQUE` accepting one NULL on SQL Server and many elsewhere; Oracle treating `''` as NULL; MySQL's case-insensitive default collation, so `Bob@x.com` and `bob@x.com` collide there and not on PostgreSQL; and which DDL rewrites a table or blocks writes.

**`runtime-failure-modes`** covers the failures with no error, no warning and no failed test — plus the two that only fail *outside* development, which local testing actively confirms as working:

- `process.exit()` truncates stdout when it is a **pipe** rather than a TTY, so a CLI loses its output exactly when used inside a script — the case nobody tests interactively.
- Module-scope state is **per process**: under `cluster` a rate limiter allows N times its limit and a lock locks nothing.

## The guard, again

`tests/fetch-docs-live.test.ts` pins the url-less list for the same reason its sibling pins the local-less one — a KB-only entry must be a deliberate act, not a forgotten field. It failed correctly and is updated.

## Process

Clone made outside this repository, deleted immediately after the push, `ls knowledge` verified clean — CLAUDE.md steps 1, 5 and 6.

## Verification

Documentation server builds; suite passes 141/141. All CI gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zdcEoMnLUwX5kqE1hyhWu
